### PR TITLE
Add @jt.kernel decorator for Triton-style kernel[grid](...) launches

### DIFF
--- a/jax_triton/__init__.py
+++ b/jax_triton/__init__.py
@@ -15,18 +15,19 @@
 """Library for JAX-Triton integrations."""
 
 __all__ = [
-    "utils",
-    "triton_call",
-    "cdiv",
-    "next_power_of_2",
-    "strides_from_shape",
-    "__version__",
-    "__version_info__",
+  "utils",
+  "triton_call",
+  "kernel",
+  "cdiv",
+  "next_power_of_2",
+  "strides_from_shape",
+  "__version__",
+  "__version_info__",
 ]
 
 from jax._src.lib import gpu_triton
 from jax_triton import utils
-from jax_triton.triton_lib import triton_call
+from jax_triton.triton_lib import triton_call, kernel
 from jax.experimental.pallas import cdiv
 from jax.experimental.pallas import next_power_of_2
 from jax.experimental.pallas import strides_from_shape

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -404,6 +404,116 @@ _BACKEND_OPTIONS_FIELD_NAMES = {
 }
 
 
+class JTKernel:
+  def __init__(self, kernel, triton_call_kwargs):
+    if not isinstance(
+      kernel,
+      (
+        triton.JITFunction,
+        gl_runtime.GluonJITFunction,
+        autotuner.Heuristics,
+        autotuner.Autotuner,
+        JTKernel,
+      ),
+    ):
+      raise ValueError(
+        "`kernel` must be a `JTKernel` or Triton's `JITFunction`, `GluonJITFunction`, `Heuristics` or `Autotuner` object."
+      )
+
+    if isinstance(kernel, JTKernel):
+      triton_call_kwargs = {**kernel.triton_call_kwargs, **triton_call_kwargs}
+      kernel = kernel.kernel
+
+    self.kernel = kernel
+
+    if "grid" in triton_call_kwargs:
+      raise ValueError("grid must be provided as an indexing argument to this object")
+
+    # This code runs only once at the kernel declaration site, so we can perform
+    # as much validation as possible here rather than on every kernel launch.
+    if "out_names" in triton_call_kwargs:
+      # We rely on the user to correctly specify the order of elements in "out_names"
+      # to match the kernel's signature. We validate this as thoroughly as possible here.
+      triton_call_kwargs = self._validate_out_names(kernel, triton_call_kwargs)
+
+    self.triton_call_kwargs = triton_call_kwargs
+
+  @staticmethod
+  def _validate_out_names(kernel, triton_call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Validates the ordering of elements in triton_call_kwargs['out_names'] as
+    thoroughly as possible."""
+    out_names = triton_call_kwargs["out_names"]
+    if isinstance(out_names, (str, int)):
+      out_names = (out_names,)
+    elif isinstance(out_names, list):  # normalize lists to tuples here
+      out_names = tuple(out_names)
+    elif not isinstance(out_names, tuple):
+      raise ValueError("out_names must be a string, or a tuple of specific format")
+    triton_call_kwargs["out_names"] = out_names
+
+    jtfu = JTJITFunction(kernel)  # refactor this out if other validation funcs appear
+    arg_names = jtfu.arg_names
+    last_idx = -1
+    for i, out_elm in enumerate(out_names):
+      is_tuple = isinstance(out_elm, tuple)
+      if is_tuple and len(out_elm) <= 0:
+        raise ValueError(f"out_names[{i}] must be a nonempty tuple")
+      if is_tuple and any(not isinstance(e, int) for e in out_elm[1:]):
+        raise ValueError(
+          "A tuple form of out_names must contain only ints beyond the first element"
+        )
+      is_first_string = is_tuple and isinstance(out_elm[0], str)
+      if isinstance(out_elm, str) or is_first_string:
+        try:
+          param_idx = arg_names.index(out_elm[0] if is_first_string else out_elm)
+        except ValueError:
+          raise ValueError(f"out_names[{i}] must be a valid kernel parameter name")
+        # without args/kwargs we can't look deeper anyway
+      else:
+        param_idx = out_elm[0] if is_tuple else out_elm
+        if not isinstance(out_elm, int):
+          raise ValueError(f"out_names[{i}] must be an int or a string")
+
+      if param_idx <= last_idx:
+        raise ValueError(
+          "The order of elements in out_names must follow the kernel's signature"
+        )
+      last_idx = param_idx
+    return triton_call_kwargs
+
+  def __getitem__(self, grid):
+    return lambda *args, **kwargs: triton_call(
+      *args, kernel=self.kernel, grid=grid, **self.triton_call_kwargs, **kwargs
+    )
+
+
+def kernel(fn=None, **kwargs):
+  """A decorator that wraps a Triton/Gluon kernel function and returns a `JTKernel`
+  object that stores kwargs to be forwarded to `triton_call()` at launch time.
+
+  It can be used in two ways:
+
+  - @jt.kernel
+    @triton.jit  # or @triton.experimental.gluon.jit
+    def kernel_func(x, y, z):
+      ...
+  - @jt.kernel(out_names="z")  # or any other key-value pairs accepted by triton_call()
+    @triton.jit
+    def kernel_func(x, y, z):
+      ...
+
+  The resulting `JTKernel` can be launched with a given grid using the familiar
+  Triton syntax `kernel_func[grid](x, y)`. Note that output arguments remain
+  implicit and must not be passed to the launcher.
+  """
+  if len(kwargs) == 0 or fn is not None:
+    if fn is None:
+      raise ValueError("`kernel` decorator must be used with a kernel function")
+    return JTKernel(fn, kwargs)
+
+  return functools.partial(JTKernel, triton_call_kwargs=kwargs)
+
+
 # nb: the class name is purposely distinct from Triton's JITFunction to simplify writing
 # comments and docstrings, and make them unambiguous without additional context.
 class JTJITFunction:
@@ -434,6 +544,8 @@ class JTJITFunction:
     | Self,
   ):
     # peel off several potential wrapper layers to get to the JITFunction object
+    if isinstance(fn, JTKernel):
+      fn = fn.kernel
     if isinstance(fn, JTJITFunction):
       fn = fn.fn
     if isinstance(fn, autotuner.Autotuner):

--- a/tests/aliasing_test.py
+++ b/tests/aliasing_test.py
@@ -175,6 +175,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     """Tuple coordinate drilling into a specific element of a compound param.
     Tests both ("name", idx) and (int, idx) forms."""
 
+    @jt.kernel
     @triton.jit
     def _k(Ptrs, val_ptr, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -185,15 +186,14 @@ class TritonCallAliasingTest(parameterized.TestCase):
     a = jnp.array([10.0], dtype=jnp.float32)
     b = jnp.array([20.0], dtype=jnp.float32)
     val = jnp.array([5.0], dtype=jnp.float32)
-    out = jt.triton_call(
-      (a, b), val, 1, input_output_aliases=[alias_spec], kernel=_k, grid=(1,)
-    )
+    out = _k[(1,)]((a, b), val, 1, input_output_aliases=[alias_spec])
     np.testing.assert_array_equal(out, jnp.array([25.0]))
 
   def test_nested_list_structured_output(self):
     """input_output_aliases=[0, [1, 2]] returns (flat, (nested, nested)) and
     related tests"""
 
+    @jt.kernel
     @triton.jit
     def _k(ptr0, ptr1, ptr2, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -205,9 +205,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     b = jnp.array([20.0], dtype=jnp.float32)
     c = jnp.array([30.0], dtype=jnp.float32)
 
-    result = jt.triton_call(
-      a, b, c, BLOCK=1, input_output_aliases=[0, [1, 2]], kernel=_k, grid=1
-    )
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[0, [1, 2]])
     self.assertIsInstance(result, tuple)
     self.assertEqual(len(result), 2)
     np.testing.assert_array_equal(result[0], jnp.array([11.0]))
@@ -216,9 +214,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     np.testing.assert_array_equal(result[1][0], jnp.array([22.0]))
     np.testing.assert_array_equal(result[1][1], jnp.array([33.0]))
 
-    result = jt.triton_call(
-      a, b, c, BLOCK=1, input_output_aliases=[2, [0, 1]], kernel=_k, grid=1
-    )
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[2, [0, 1]])
     self.assertIsInstance(result, tuple)
     self.assertEqual(len(result), 2)
     np.testing.assert_array_equal(result[0], jnp.array([33.0]))
@@ -228,9 +224,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     np.testing.assert_array_equal(result[1][1], jnp.array([22.0]))
     assert jttl.JTJITFunction(_k).compiled_kernels_cache_size == 1
 
-    result = jt.triton_call(
-      a, b, c, BLOCK=1, input_output_aliases=[[1, 0], 2], kernel=_k, grid=1
-    )
+    result = _k[1](a, b, c, BLOCK=1, input_output_aliases=[[1, 0], 2])
     self.assertIsInstance(result, tuple)
     self.assertEqual(len(result), 2)
     np.testing.assert_array_equal(result[1], jnp.array([33.0]))
@@ -256,6 +250,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     """Pure output + aliased output in a single call.
     Exercises the return assembly: tuple(pure_outs.values()) + aliased_outs."""
 
+    @jt.kernel(out_names="out_ptr")
     @triton.jit
     def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -266,14 +261,8 @@ class TritonCallAliasingTest(parameterized.TestCase):
 
     x = jnp.array([5.0], dtype=jnp.float32)
     y = jnp.array([10.0], dtype=jnp.float32)
-    pure_out, aliased_out = jt.triton_call(
-      x,
-      y,
-      BLOCK=1,
-      out_shape=x,
-      input_output_aliases=input_output_aliases,
-      kernel=_k,
-      grid=(1,),
+    pure_out, aliased_out = _k[(1,)](
+      x, y, BLOCK=1, out_shape=x, input_output_aliases=input_output_aliases
     )
     np.testing.assert_array_equal(pure_out, x * 2)
     np.testing.assert_array_equal(aliased_out, y + x)
@@ -293,6 +282,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
   def test_mixed_multiple_pure_and_aliased_outputs(self, input_output_aliases):
     """2 pure outputs + 1 aliased output, verifying ordering."""
 
+    @jt.kernel(out_names=("out1_ptr", "out2_ptr"))
     @triton.jit
     def _k(in_ptr, inout_ptr, out1_ptr, out2_ptr, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -304,14 +294,8 @@ class TritonCallAliasingTest(parameterized.TestCase):
 
     x = jnp.array([5.0], dtype=jnp.float32)
     y = jnp.array([10.0], dtype=jnp.float32)
-    out1, out2, aliased_out = jt.triton_call(
-      x,
-      y,
-      BLOCK=1,
-      out_shape=(x, x),
-      input_output_aliases=input_output_aliases,
-      kernel=_k,
-      grid=(1,),
+    out1, out2, aliased_out = _k[(1,)](
+      x, y, BLOCK=1, out_shape=(x, x), input_output_aliases=input_output_aliases
     )
     np.testing.assert_array_equal(out1, x * 2)
     np.testing.assert_array_equal(out2, x * 3)
@@ -336,6 +320,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     """Dict out_shape combined with sequence-form input_output_aliases.
     The dict provides pure output shapes; aliased shapes are inferred from inputs."""
 
+    @jt.kernel
     @triton.jit
     def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -346,14 +331,12 @@ class TritonCallAliasingTest(parameterized.TestCase):
 
     x = jnp.array([5.0], dtype=jnp.float32)
     y = jnp.array([10.0], dtype=jnp.float32)
-    pure_out, aliased_out = jt.triton_call(
+    pure_out, aliased_out = _k[(1,)](
       x,
       y,
       BLOCK=1,
       out_shape={out_shape_key: x},
       input_output_aliases=input_output_aliases,
-      kernel=_k,
-      grid=(1,),
     )
     np.testing.assert_array_equal(pure_out, x * 2)
     np.testing.assert_array_equal(aliased_out, y + x)
@@ -370,6 +353,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     """Deprecated dict-form aliases where out_shape carries both pure and
     aliased shapes, split by out_names count."""
 
+    @jt.kernel(out_names="out_ptr")
     @triton.jit
     def _k(in_ptr, inout_ptr, out_ptr, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -380,14 +364,12 @@ class TritonCallAliasingTest(parameterized.TestCase):
 
     x = jnp.array([5.0], dtype=jnp.float32)
     y = jnp.array([10.0], dtype=jnp.float32)
-    pure_out, aliased_out = jt.triton_call(
+    pure_out, aliased_out = _k[1](
       x,
       y,
       out_shape=(x, y),  # the first is pure output, the second is aliased
       BLOCK=1,
       input_output_aliases={aliasing_key: 1},
-      kernel=_k,
-      grid=1,
     )
     np.testing.assert_array_equal(pure_out, x * 2)
     np.testing.assert_array_equal(aliased_out, y + x)
@@ -396,6 +378,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
     """String aliasing a compound param whose arrays have different dtypes.
     Verifies functools.reduce(_unpack_arg, ...) creates correct per-dtype shapes."""
 
+    @jt.kernel
     @triton.jit
     def _k(Ptrs, BLOCK: tl.constexpr):
       offs = tl.arange(0, BLOCK)
@@ -406,7 +389,7 @@ class TritonCallAliasingTest(parameterized.TestCase):
 
     f = jnp.array([5.0], dtype=jnp.float32)
     i = jnp.array([100], dtype=jnp.int32)
-    out = jt.triton_call((f, i), 1, input_output_aliases="Ptrs", kernel=_k, grid=(1,))
+    out = _k[(1,)]((f, i), 1, input_output_aliases="Ptrs")
     self.assertIsInstance(out, tuple)
     self.assertEqual(len(out), 2)
     np.testing.assert_array_equal(out[0], jnp.array([6.0], dtype=jnp.float32))

--- a/tests/outshape_test.py
+++ b/tests/outshape_test.py
@@ -35,6 +35,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
   def test_single_output(self):
     """All forms of out_shape for a single output parameter."""
 
+    @jt.kernel
     @triton.jit
     def copy_k(in_ptr, n_elements, out_ptr, BLOCK_SIZE: tl.constexpr):
       pid = tl.program_id(axis=0)
@@ -59,20 +60,15 @@ class TritonCallOutShapeTest(parameterized.TestCase):
           )
         ):
           out_names = None
-        out = jt.triton_call(
-          x,
-          x.size,
-          BLOCK_SIZE=8,
-          out_shape=out_shape,
-          out_names=out_names,
-          kernel=copy_k,
-          grid=(2,),
+        out = copy_k[(2,)](
+          x, x.size, BLOCK_SIZE=8, out_shape=out_shape, out_names=out_names
         )
         assert_expected(out)
 
   def test_multiple_outputs(self):
     """All forms of out_shape for multiple output parameters."""
 
+    @jt.kernel
     @triton.jit
     def twin_k(in_ptr, n, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
       pid = tl.program_id(axis=0)
@@ -123,20 +119,15 @@ class TritonCallOutShapeTest(parameterized.TestCase):
           )
         ):
           out_names = None
-        o1, o2 = jt.triton_call(
-          x,
-          x.size,
-          BLOCK_SIZE=8,
-          out_shape=out_shape,
-          out_names=out_names,
-          kernel=twin_k,
-          grid=(1,),
+        o1, o2 = twin_k[(1,)](
+          x, x.size, BLOCK_SIZE=8, out_shape=out_shape, out_names=out_names
         )
         assert_expected(o1, o2)
 
   def test_different_shapes(self):
     """Multiple outputs with different shapes via sequence form."""
 
+    @jt.kernel
     @triton.jit
     def split_k(in_ptr, out1_ptr, out2_ptr, BLOCK_SIZE: tl.constexpr):
       pid = tl.program_id(axis=0)
@@ -147,15 +138,14 @@ class TritonCallOutShapeTest(parameterized.TestCase):
       tl.store(out2_ptr + offs, tl.load(in_ptr + 8 + offs, mask=mask7), mask=mask7)
 
     x = jnp.arange(15, dtype=jnp.float32)
-    o1, o2 = jt.triton_call(
-      x, BLOCK_SIZE=8, out_shape=[x[:8], x[8:]], kernel=split_k, grid=(1,)
-    )
+    o1, o2 = split_k[(1,)](x, BLOCK_SIZE=8, out_shape=[x[:8], x[8:]])
     np.testing.assert_array_equal(o1, x[:8])
     np.testing.assert_array_equal(o2, x[8:])
 
   def test_different_dtypes(self):
     """Multiple outputs with different dtypes."""
 
+    @jt.kernel
     @triton.jit
     def cast_k(in_ptr, out_f32_ptr, out_i32_ptr):
       x = tl.load(in_ptr)
@@ -163,9 +153,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
       tl.store(out_i32_ptr, x.to(tl.int32))
 
     x = jnp.array([42.25], dtype=jnp.float32)
-    o_f, o_i = jt.triton_call(
-      x, out_shape=[x, x.astype(jnp.int32)], kernel=cast_k, grid=(1,)
-    )
+    o_f, o_i = cast_k[(1,)](x, out_shape=[x, x.astype(jnp.int32)])
     np.testing.assert_array_equal(o_f, x)
     self.assertEqual(o_f.dtype, jnp.float32)
     np.testing.assert_array_equal(o_i, jnp.array([42], dtype=jnp.int32))
@@ -175,6 +163,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
     """Dict out_shape + explicit out_names: ordering doesn't matter and is always
     governed by the kernel signature."""
 
+    @jt.kernel
     @triton.jit
     def twin_k(in_ptr, out_a_ptr, out_b_ptr):
       x = tl.load(in_ptr)
@@ -199,14 +188,13 @@ class TritonCallOutShapeTest(parameterized.TestCase):
         ("out_a_ptr", "out_b_ptr"),
         None,
       ]:
-        o1, o2 = jt.triton_call(
-          x, out_shape=out_shape, out_names=out_names, kernel=twin_k, grid=(1,)
-        )
+        o1, o2 = twin_k[(1,)](x, out_shape=out_shape, out_names=out_names)
         assert_expected(o1, o2)
 
   def test_compound_first(self):
     """out_shape=((a,(b,c)),d) — first output param is a compound tuple of arrays."""
 
+    @jt.kernel
     @triton.jit
     def compound_k(in_ptr, Ptrs, single_out):
       x = tl.load(in_ptr)
@@ -220,11 +208,8 @@ class TritonCallOutShapeTest(parameterized.TestCase):
     x = jnp.array([5.25])
     z = jnp.zeros((1,), dtype=jnp.float32)
 
-    compound_out, scalar_out = jt.triton_call(
-      x,
-      out_shape=((z, (z.astype(jnp.int32), z.astype(jnp.int16))), z),
-      kernel=compound_k,
-      grid=(1,),
+    compound_out, scalar_out = compound_k[(1,)](
+      x, out_shape=((z, (z.astype(jnp.int32), z.astype(jnp.int16))), z)
     )
     self.assertIsInstance(compound_out, tuple)
     self.assertEqual(len(compound_out), 2)
@@ -244,6 +229,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
   def test_compound_second(self):
     """out_shape=(a, (b,(c,d),e)) — second output param is a compound tuple of arrays."""
 
+    @jt.kernel
     @triton.jit
     def compound_k(in_ptr, single_out, Ptrs):
       x = tl.load(in_ptr)
@@ -257,14 +243,12 @@ class TritonCallOutShapeTest(parameterized.TestCase):
 
     x = jnp.array([5.25])
     z = jnp.zeros((1,), dtype=jnp.float32)
-    scalar_out, compound_out = jt.triton_call(
+    scalar_out, compound_out = compound_k[(1,)](
       x,
       out_shape=(
         z,
         (z, (z.astype(jnp.int32), z.astype(jnp.int16)), z.astype(jnp.int8)),
       ),
-      kernel=compound_k,
-      grid=(1,),
     )
     np.testing.assert_array_equal(scalar_out, x * 2)
     self.assertEqual(scalar_out.dtype, jnp.float32)
@@ -288,6 +272,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
   def test_dict_compound(self):
     """Dict form: out_shape={"Ptrs": ((a,b),c), "single_out": d} — compound dict value."""
 
+    @jt.kernel
     @triton.jit
     def compound_k(in_ptr, Ptrs, single_out):
       x = tl.load(in_ptr)
@@ -320,32 +305,29 @@ class TritonCallOutShapeTest(parameterized.TestCase):
 
       assert jttl.JTJITFunction(compound_k).compiled_kernels_cache_size == 1
 
-    compound_out, scalar_out = jt.triton_call(
+    compound_out, scalar_out = compound_k[(1,)](
       x,
       out_shape={
         "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
         "single_out": z,
       },
-      kernel=compound_k,
-      grid=(1,),
     )
     assert_expected(compound_out, scalar_out)
 
     # Reversed dict key ordering — result must be identical (kernel signature order wins)
-    compound_out2, scalar_out2 = jt.triton_call(
+    compound_out2, scalar_out2 = compound_k[(1,)](
       x,
       out_shape={
         "single_out": z,
         "Ptrs": ((z, z.astype(jnp.int32)), z.astype(jnp.int16)),
       },
-      kernel=compound_k,
-      grid=(1,),
     )
     assert_expected(compound_out2, scalar_out2)
 
   def test_integer_interleaved(self):
     """Integer out_names for output params interleaved with a kwarg-only scalar input."""
 
+    @jt.kernel
     @triton.jit
     def interleaved_k(in_ptr, out1_ptr, scale, out2_ptr):
       x = tl.load(in_ptr)
@@ -355,9 +337,7 @@ class TritonCallOutShapeTest(parameterized.TestCase):
     x = jnp.array([5.25])
     z = jnp.zeros((1,), dtype=jnp.float32)
 
-    o1, o2 = jt.triton_call(
-      x, out_shape=[z, z], out_names=(1, 3), scale=3.0, kernel=interleaved_k, grid=(1,)
-    )
+    o1, o2 = interleaved_k[(1,)](x, out_shape=[z, z], out_names=(1, 3), scale=3.0)
     np.testing.assert_array_equal(o1, x)
     np.testing.assert_array_equal(o2, x * 3)
 

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -384,15 +384,13 @@ class TritonKernelCallTest(parameterized.TestCase):
 
   @parameterized.parameters(42.0, np.float32(42.0))
   def test_add_float_scalar(self, scalar):
+    @jt.kernel
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
     x = jnp.array([1.0])
-    np.testing.assert_allclose(
-      jt.triton_call(x, scalar, out_shape=x, kernel=add_scalar_kernel, grid=1),
-      x + scalar,
-    )
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
 
   @parameterized.product(
     mul=[None, 1, 1.0, 3.14],
@@ -493,25 +491,41 @@ class TritonKernelCallTest(parameterized.TestCase):
     self.assertEqual(jttl.JTJITFunction(kernel2).compiled_kernels_cache_size, 4)
     np.testing.assert_array_equal(rets, [1, 2, 3, 7, 1])
 
+  def test_jit_function_arg(self):
+    @triton.jit
+    def mul_jit_function(x, y):
+      return x * y
+
+    @triton.jit
+    def apply_binary_op(x, combine_op):
+      return combine_op(x, x)
+
+    @jt.kernel
+    @triton.jit
+    def square_kernel_jit_function(in_ptr, out_ptr, BLOCK_SIZE: tl.constexpr):
+      offsets = tl.arange(0, BLOCK_SIZE)
+      in_data = tl.load(in_ptr + offsets)
+      # pass a JITFunction into another JITFunction
+      out_data = apply_binary_op(in_data, mul_jit_function)
+      tl.store(out_ptr + offsets, out_data)
+
+    BLOCK_SIZE = 16
+    x = jnp.full((BLOCK_SIZE,), 3.0)
+    expect = jnp.full((BLOCK_SIZE,), 9.0, dtype=x.dtype)
+
+    out = square_kernel_jit_function[(1,)](x, BLOCK_SIZE=BLOCK_SIZE, out_shape=x)
+    np.testing.assert_allclose(out, expect)
+
   def test_explicit_compute_capability(self):
     scalar = np.float32(8)
 
+    @jt.kernel(compute_capability=jt.get_compute_capability(0))
     @triton.jit
     def add_scalar_kernel(x_ptr, y, output_ptr):
       tl.store(output_ptr, tl.load(x_ptr) + y)
 
     x = jnp.array([1.0])
-    np.testing.assert_allclose(
-      jt.triton_call(
-        x,
-        scalar,
-        kernel=add_scalar_kernel,
-        out_shape=x,
-        grid=1,
-        compute_capability=jt.get_compute_capability(0),
-      ),
-      x + scalar,
-    )
+    np.testing.assert_allclose(add_scalar_kernel[1](x, scalar, out_shape=x), x + scalar)
 
   def test_single_namespace_for_constexprs_and_backend_options(self):
     """Checks that metaparams of triton_call() are passed to the kernel and to backend
@@ -600,6 +614,7 @@ class TritonKernelCallTest(parameterized.TestCase):
       self.assertEqual(jt_cache_size(), 2)
 
   def test_kernel_cache_same_kernel_different_params(self):
+    @jt.kernel(out_names="output_ptr")
     @triton.jit
     def silly_add_kernel(x_ptr, y_ptr, output_ptr):
       pid = tl.program_id(axis=0)
@@ -607,11 +622,7 @@ class TritonKernelCallTest(parameterized.TestCase):
 
     def silly_add(n, dtype="float32"):
       x, y = create_random_inputs([n], dtype=dtype)
-      return (
-        jt.triton_call(x, y, out_shape=x, kernel=silly_add_kernel, grid=x.size),
-        x,
-        y,
-      )
+      return silly_add_kernel[x.size](x, y, out_shape=x), x, y
 
     jt_kernel = jttl.JTJITFunction(silly_add_kernel)
     jt_cache_size = lambda: jt_kernel.compiled_kernels_cache_size
@@ -781,6 +792,34 @@ class TritonKernelCallTest(parameterized.TestCase):
     out = add(x, y, kernel=kernel, input_output_aliases={0: 0})
     np.testing.assert_allclose(out, expected)
 
+  def test_kernel_in_thread(self):
+    # Inspired by Triton's test. Verifies that calling in a new thread sets a valid
+    # device context.
+    buf = jnp.zeros((38016 * 1024,), dtype=jnp.float32)
+
+    @jt.kernel(out_names="out")
+    @triton.jit
+    def _kernel(P, BLOCK: tl.constexpr, out):
+      pid = tl.program_id(0).to(tl.int64)
+      offset = pid * BLOCK + tl.arange(0, BLOCK)
+
+      p = tl.load(P + offset)
+      tl.store(out + offset, p + 1)
+
+    def call_triton():
+      nonlocal buf
+      N = buf.size
+      grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]),)
+      out = _kernel[grid](buf, BLOCK=1024, out_shape=buf)
+      np.testing.assert_array_equal(buf + 1, out)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    call_triton()
+    with ThreadPoolExecutor(1) as pool:
+      future = pool.submit(call_triton)
+      future.result()
+
   def test_autodiff_exception(self):
     x, y = create_random_inputs([10, 100], dtype="float32")
     with self.assertRaisesRegex(
@@ -798,3 +837,185 @@ class TritonKernelCallTest(parameterized.TestCase):
       r"jax\.custom_batching\.custom_vmap.*",
     ):
       jax.vmap(lambda x, y: add(x, y, BLOCK_SIZE=32))(x, y)
+
+  def test_memory_leak(self):
+    # Inspired by Triton's test.
+
+    @jt.kernel(out_names="out_ptr0")
+    @triton.jit
+    def kernel(in_ptr0, xnumel, XBLOCK: tl.constexpr, out_ptr0):
+      xnumel = 10
+      xoffset = tl.program_id(0) * XBLOCK
+      xindex = xoffset + tl.arange(0, XBLOCK)[:]
+      xmask = xindex < xnumel
+      x0 = xindex
+      tmp0 = tl.load(in_ptr0 + (x0), xmask)
+      tl.store(out_ptr0 + (x0 + tl.zeros([XBLOCK], tl.int32)), tmp0, xmask)
+
+    import gc
+    import tracemalloc
+
+    tracemalloc.start()
+    try:
+      inp = random.normal(random.key(0), (10,))
+      out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      gc.collect()
+      begin, _ = tracemalloc.get_traced_memory()
+      for _ in range(200):  # originally was 100
+        out = kernel[(10,)](inp, 10, XBLOCK=16, out_shape=inp)
+      del out
+      gc.collect()
+      end, _ = tracemalloc.get_traced_memory()
+      assert end - begin < 71000  # originally this was 30000, but we store extra data
+      # in a JTKernel object and there is JAX's internal caching in the Primitive system
+      # on top of that, so +41k seems reasonable (estimated with the original 100
+      # iterations in the loop above, then the range was raised to 200).
+      # The margin is just about 100 bytes on this system, so if on another system it's
+      # slightly different (i.e., a bit larger and causes a failure), just update the
+      # threshold above.
+    finally:
+      tracemalloc.stop()
+
+  @parameterized.product(
+    signed=[False, True],
+    width=[8, 16, 32, 64, 1],
+  )
+  def test_int_annotation(self, signed, width):
+    # Inspired by an original Triton test.
+    # We could add similar tests for float, but it seems redundant: we delegate to the
+    # original Triton code, and if ints work, everything else should too.
+    if width == 1 and signed:
+      return
+
+    def annotated_function(return_type=None, **arg_types):
+      """A decorator to add annotations to a function."""
+
+      def decorator(func):
+        func.__annotations__ = {**arg_types, "return": return_type}
+        return func
+
+      return decorator
+
+    @jt.kernel
+    @triton.jit
+    @annotated_function(v=f"tl.{'' if signed else 'u'}int{width}")
+    def _kernel(v, X):
+      tl.store(X + v, v)
+
+    _kernel[(1,)](3, out_shape=jnp.zeros(1), _store_asm=True)
+
+    asm = jttl.JTJITFunction(_kernel).asm
+    assert len(asm) == 1
+    ttir = next(iter(asm.values())).get("ttir")
+
+    pfx = "si" if signed else "ui"
+    if not signed and width < 64:
+      assert "arith.extui %v" in ttir
+    assert f"%v: i{width}" in ttir
+    assert f"arith.{pfx}tofp" in ttir
+
+  def test_err_constexpr_and_do_not_specialize(self):
+    # Inspired by the original Triton test. Verifies that our code doesn't break
+    # `do_not_specialize` functionality. Related to the previous test: we delegate to
+    # Triton's own processing here and verify it remains intact.
+    @jt.kernel
+    @triton.jit(do_not_specialize=["N"])
+    def kernel(out_ptr, N: tl.constexpr):
+      pass
+
+    with self.assertRaisesRegex(
+      triton.compiler.errors.CompilationError,
+      r"N marked as constexpr and listed in do_not_specialize",
+    ):
+      kernel[(1,)](5, out_shape=jnp.zeros(1))  # out_shape is needed to prevent DCE
+
+  def test_kernel_default_arg(self):
+    # Inspired by an original Triton test.
+    global GLOBAL_DEFAULT_ARG
+
+    @jt.kernel
+    @triton.jit
+    def kernel(X, i: tl.constexpr = GLOBAL_DEFAULT_ARG):
+      tl.store(X, i)
+
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    # Changing the global variable should not change the default argument in
+    # `kernel`.  That value gets set at the time the function is declared.
+    GLOBAL_DEFAULT_ARG = 2
+    x = kernel[(1,)](out_shape=jnp.zeros(1))
+    assert x == jnp.ones_like(x)
+
+    assert jttl.JTJITFunction(kernel).compiled_kernels_cache_size == 1
+
+  def test_readme(self):
+    """Code for the README example; effectively an integration test of many features
+    at once, including string passing (not tested elsewhere), precise partial aliasing,
+    and pure outputs."""
+    from triton.language.extra import libdevice
+    from typing import NamedTuple
+    import time
+
+    class Function(NamedTuple):
+      fn: tl.constexpr
+      captured: tuple
+
+    @triton.jit
+    def func1(x_ptr, y_ptr: tl.const, SIZE: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      x = tl.load(x_ptr + off)
+      y = tl.load(y_ptr + off)
+      x1 = libdevice.sin(x)
+      x2 = libdevice.cos(x)
+      z = x1 * x1 + x2 * x2
+      tl.store(x_ptr + off, z)
+      y = libdevice.asin(y) + libdevice.acos(y)
+      return z, libdevice.floor(2 * y)
+
+    @triton.jit
+    def floor_of_func(values, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      return libdevice.floor(getattr(libdevice, FUNC_NAME)(values))
+
+    @triton.jit
+    def aggregate(Ptrs):
+      z = tl.zeros([], tl.float32)
+      for i in tl.static_range(len(Ptrs)):
+        z += Ptrs[i]
+      return z
+
+    @jt.kernel
+    @triton.jit
+    def kernel(capture, out_ptr, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      t1, t2 = capture.fn(*capture.captured, SIZE=SIZE)
+      t3 = floor_of_func(t1, SIZE=SIZE, FUNC_NAME=FUNC_NAME)
+      t4 = t2 * t3
+      result = aggregate((t4, t4 * t4)).to(tl.int32)
+      tl.store(out_ptr + off, result)
+
+    size = 8
+    k1, k2 = random.split(random.key(time.perf_counter_ns()), 2)
+    x = random.uniform(k1, (size,), dtype=jnp.float32)
+    y = random.uniform(k2, (size,), dtype=jnp.float32)
+
+    fn = Function(func1, (x, y))
+    out, x = kernel[(1,)](
+      fn,  # essentially a tuple of (func_name, (2 arrays in a subtuple))
+      SIZE=size,
+      FUNC_NAME="exp",
+      out_shape=jnp.zeros(size, dtype=jnp.int32),
+      input_output_aliases=("capture", 1, 0),  # path into `capture`: index 1 of
+      # `captured` tuple, then index 0 of that subtuple, i.e. array `x`. As a tuple
+      # path, it references exactly that one array (not the whole subtuple).
+    )
+    np.testing.assert_array_equal(out, jnp.full((size,), 42, dtype=jnp.int32))
+    assert out.dtype == jnp.int32
+    np.testing.assert_allclose(x, jnp.full((size,), 1.0, dtype=jnp.float32), rtol=5e-7)
+    assert x.dtype == jnp.float32
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()

--- a/tests/triton_test.py
+++ b/tests/triton_test.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from absl.testing import absltest
+from absl.testing import parameterized
 
 import jax
-from jax import config
+from jax import config, random
 import jax.numpy as jnp
 import jax_triton as jt
 import numpy as np
+import scipy
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice
@@ -88,7 +90,7 @@ def tanh_kernel(
   tl.store(output_ptr + offsets, output, mask=mask)
 
 
-class TritonTest(absltest.TestCase):
+class TritonTest(parameterized.TestCase):
 
   def test_add_kernel(self):
 
@@ -127,5 +129,44 @@ class TritonTest(absltest.TestCase):
     np.testing.assert_allclose(tanh(x), np.tanh(x))
 
 
-if __name__ == '__main__':
+  @parameterized.product(
+    dtype_str=["float32", "float64"],
+    funcs=[
+      # ("j0", lambda x: jax.scipy.special.bessel_jn(x, v=0)[0]),
+      # Surprisingly, the above produces NaNs, possibly due to an inherent instability
+      # in the Miller backward recurrence algorithm used internally. The exact cause is
+      # unknown, but using scipy is acceptable for tests.
+      ("j0", lambda x: jnp.array(scipy.special.j0(np.asarray(x)))),
+      ("j1", lambda x: jnp.array(scipy.special.j1(np.asarray(x)))),
+      ("y0", lambda x: jnp.array(scipy.special.y0(np.asarray(x)))),
+      ("y1", lambda x: jnp.array(scipy.special.y1(np.asarray(x)))),
+      ("cyl_bessel_i0", lambda x: jnp.array(scipy.special.i0(np.asarray(x)))),
+      ("cyl_bessel_i1", lambda x: jnp.array(scipy.special.i1(np.asarray(x)))),
+    ],
+  )
+  def test_bessel(self, dtype_str, funcs):
+    # Inspired by the original Triton test.
+    libdevice_fn, jax_special_fn = funcs
+    SIZE = 128
+    dtype = getattr(jnp, dtype_str)
+
+    x = random.normal(random.key(42), (SIZE,), dtype=dtype)
+    y_ref = jax_special_fn(x)
+
+    @jt.kernel
+    @triton.jit
+    def kernel(in_p, out_p, fn: tl.constexpr, SIZE: tl.constexpr):
+      off = tl.arange(0, SIZE)
+      x = tl.load(in_p + off)
+      res = getattr(libdevice, fn)(x)
+      tl.store(out_p + off, res)
+
+    y_exp = kernel[(1,)](
+      x, fn=libdevice_fn, SIZE=SIZE, num_warps=4, num_ctas=1, out_shape=x
+    )
+
+    np.testing.assert_allclose(y_exp, y_ref, equal_nan=True, rtol=1e-6)
+
+
+if __name__ == "__main__":
   absltest.main()

--- a/tests/tuple_test.py
+++ b/tests/tuple_test.py
@@ -56,6 +56,7 @@ class TupleTest(parameterized.TestCase):
       for i in tl.static_range(len(values)):
         tl.store(Ptrs[i], values[i])
 
+    @jt.kernel(out_names="Ptrs")
     @triton.jit
     def _tuple_index(_0, _1: tl.constexpr, values, _2, _3: tl.constexpr, _4, Ptrs):
       values = _tuple_increment(values)
@@ -63,12 +64,11 @@ class TupleTest(parameterized.TestCase):
 
     vals = tuple(i + 1 for i in range(size))
     rets = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in vals)
-    rets = jt.triton_call(
-      0, 0, vals, 0, 0, 0, out_shape=[rets], kernel=_tuple_index, grid=(1,)
-    )
+    rets = _tuple_index[(1,)](0, 0, vals, 0, 0, 0, out_shape=[rets])
     assert vals == tuple(x - 1 for x in rets)
 
   def test_assign(self):
+    @jt.kernel
     @triton.jit
     def _tuple_assign(XPtrs, YPtrs, values):
       # assign from tuple
@@ -87,14 +87,7 @@ class TupleTest(parameterized.TestCase):
     vals = (2.0, 3.0, None)
     x = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(2))
     y = tuple(jnp.zeros((1,), dtype=jnp.float32) for _ in range(3))
-    x, y = jt.triton_call(
-      x,
-      y,
-      vals,
-      input_output_aliases=["XPtrs", "YPtrs"],
-      kernel=_tuple_assign,
-      grid=(1,),
-    )
+    x, y = _tuple_assign[(1,)](x, y, vals, input_output_aliases=["XPtrs", "YPtrs"])
     assert x[0] == vals[0]
     assert x[1] == vals[1]
     assert y[0] == vals[0]
@@ -106,6 +99,7 @@ class TupleTest(parameterized.TestCase):
     def _tuple_ret(a, b):
       return a + b, a - b, a * b
 
+    @jt.kernel
     @triton.jit
     def with_fn(X, Y, A, B, C):
       x = tl.load(X)
@@ -115,6 +109,7 @@ class TupleTest(parameterized.TestCase):
       tl.store(B, b)
       tl.store(C, c)
 
+    @jt.kernel
     @triton.jit
     def without_fn(X, Y, A, B, C):
       x = tl.load(X)
@@ -127,9 +122,7 @@ class TupleTest(parameterized.TestCase):
     x = jnp.array([1.3], dtype=jnp.float32)
     y = jnp.array([1.9], dtype=jnp.float32)
     for kernel in [with_fn, without_fn]:
-      a_tri, b_tri, c_tri = jt.triton_call(
-        x, y, num_warps=1, out_shape=(x, x, x), kernel=kernel, grid=(1,)
-      )
+      a_tri, b_tri, c_tri = kernel[(1,)](x, y, num_warps=1, out_shape=(x, x, x))
       a_ref, b_ref, c_ref = x + y, x - y, x * y
       assert a_tri == a_ref
       assert b_tri == b_ref
@@ -145,6 +138,7 @@ class TupleTest(parameterized.TestCase):
       tl.store(Ptr + 8, tuple1[2][1][0])
       tl.store(Ptr + 9, tl.load(tuple1[2][1][2]))
 
+    @jt.kernel(out_names="Ptr")
     @triton.jit
     def _tuple_serialize(N1, tuple1, cst1: tl.constexpr, val1, tuple2, Ptr):
       tl.static_assert(N1 is None)
@@ -161,15 +155,13 @@ class TupleTest(parameterized.TestCase):
     x1 = jnp.array([12], dtype=jnp.int32)
     y0 = jnp.array([10], dtype=jnp.int32)
 
-    z = jt.triton_call(
+    z = _tuple_serialize[(1,)](
       None,
       (x0, (1, None, x1, tl.constexpr(4))),
       20,
       1,
       (y0,),
       out_shape=jnp.empty((10,), dtype=jnp.int32),
-      kernel=_tuple_serialize,
-      grid=(1,),
     )
     ref = jnp.array([8, 1, 12, 21, 10, 15, -1, 8, 1, 12], dtype=jnp.int32)
     np.testing.assert_array_equal(z, ref)
@@ -200,6 +192,7 @@ class TupleTest(parameterized.TestCase):
       mask = (offs_m[:, None] < Tensor.shape[0]) & (offs_n[None, :] < Tensor.shape[1])
       return mask
 
+    @jt.kernel
     @triton.jit
     def _namedtuple_kernel(
       closure, _X, Y, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr
@@ -225,19 +218,11 @@ class TupleTest(parameterized.TestCase):
     function = Function(mul, (a,))
     tx = Tensor(x, x.shape, jax_strides(x))
     ty = Tensor(y, y.shape, jax_strides(y))
-    y = jt.triton_call(
-      function,
-      tx,
-      ty,
-      64,
-      64,
-      input_output_aliases="Y",
-      kernel=_namedtuple_kernel,
-      grid=(1,),
-    )
+    y = _namedtuple_kernel[(1,)](function, tx, ty, 64, 64, input_output_aliases="Y")
     np.testing.assert_allclose(y, x[:16, :16] * a)
 
   def test_passing_nested_tuple_with_constexpr(self):
+    @jt.kernel
     @triton.jit
     def _nested_tuple_kernel(x, out_ptr):
       # This creates a new scope, which will force a copy of liveins. It's
@@ -247,14 +232,12 @@ class TupleTest(parameterized.TestCase):
         tl.static_assert(x[1][0] == 2)
         tl.static_assert(len(x[2]) == 0)  # to tests JT specific empty tuple passing
 
-    jt.triton_call(  # out_shape is needed to prevent DCE
-      ((1,), (tl.constexpr(2),), tuple()),
-      out_shape=jnp.zeros(1),
-      kernel=_nested_tuple_kernel,
-      grid=(1,),
+    _nested_tuple_kernel[(1,)](  # out_shape is needed to prevent DCE
+      ((1,), (tl.constexpr(2),), tuple()), out_shape=jnp.zeros(1)
     )
 
   def test_passing_tuple_to_make_tensor_descriptor(self):
+    @jt.kernel
     @triton.jit
     def m_to_the_n(X_base, shape, strides, m_n, BLOCK_DIM: tl.constexpr):
       tl.static_assert(isinstance(strides[1].type, tl.constexpr_type))
@@ -275,15 +258,8 @@ class TupleTest(parameterized.TestCase):
 
     x = jnp.arange(0, 16).reshape(4, 4)
     expected_x = 8 * x.copy()
-    x = jt.triton_call(
-      x,
-      x.shape,
-      jax_strides(x),
-      (2, 3),
-      x.shape[0],
-      input_output_aliases="X_base",
-      kernel=m_to_the_n,
-      grid=(1,),
+    x = m_to_the_n[(1,)](
+      x, x.shape, jax_strides(x), (2, 3), x.shape[0], input_output_aliases="X_base"
     )
     np.testing.assert_array_equal(x, expected_x)
 


### PR DESCRIPTION
Introduce a `JTKernel` wrapper and a `jt.kernel` decorator that bind a Triton `JITFunction` (or `GluonJITFunction`, `Autotuner`, `Heuristics`, or another `JTKernel`) to `triton_call` kwargs at declaration time and expose the familiar Triton launch syntax: `my_kernel[grid](args...)`.

The decorator can be used bare (`@jt.kernel`) or parameterized (`@jt.kernel(out_names=..., compute_capability=..., ...)`); stored kwargs are forwarded to `triton_call` on every launch and merged when nesting `JTKernel`s. `grid` is supplied via `__getitem__`, so it is rejected in the stored kwargs. `triton_call` is also taught to unwrap a `JTKernel` passed as `kernel=`.

`out_names` is normalized (str/int -> 1-tuple, list -> tuple) and validated up front: each entry must be a kernel parameter name, an integer index, or a `(name_or_index, *int_path)` tuple; entries must follow the kernel's signature order; tuple paths must be non-empty and contain only ints beyond the first element. Doing this once at declaration avoids repeating the work on every launch.

Migrate the aliasing and triton_call tests to the new launch syntax and add tests covering: passing a `JITFunction` as a kernel argument, thread-context safety, a tracemalloc-based memory-leak check (threshold adjusted to account for `JTKernel` state and JAX primitive caching), int-annotation propagation to TTIR, interaction with Triton's `do_not_specialize`, constexpr default arguments snapshotted at declaration time, and a README-style end-to-end example exercising string passing and precise partial tuple aliasing.

No behavior change for existing `jt.triton_call(...)` callers; the new decorator is purely additive.