### PR TITLE
2.4 Release 0.5.0: finalize updates, drop aliased-input support from …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# 0.5.0
+## Breaking changes
+- `float` now follows upstream convention and is represented as `fp32`, instead of the
+old `fp64`
+- `zeroed_outputs=` parameter of `triton_call()` no longer supports zeroing of aliased
+input-output arguments.
+
+## New features / bug fixes
+- all possible backend initialization options are now fully supported and handled
+similarly to upstream (via a single `kwargs` dictionary).
+- support for `@jt.kernel` decorator and a concise Triton-native form of launching a
+kernel with `kernel[grid](*args, **kwargs)` syntax.
+- `out_names=` triton_call() parameter introduced to let specify output-only parameters
+in the kernel's signature. Alternatively, a new dictionary form of `out_shape=` is
+introduced for the same purpose.
+- arrays and other runtime values can now also be passed as key-value arguments to the
+launcher when `out_names=` is set or if a new dictionary form of `out_shape=` is used.
+- handling of kernel argument specialization and default values is now fully delegated
+to the upstream Triton code, which enables full support for default values, kernel
+parameter annotations, related `@triton.jit()` arguments such as `do_not_specialize`,
+and also using tuples (including deeply nested ones), callables, or strings as kernel
+arguments.
+- `out_shape`, `input_output_aliases` and `zeroed_outputs` handling is fully reworked
+to support nested tuples and is now based on a kernel signature coordinate system,
+instead of flat array indices, leading to a much clearer launcher syntax.
+- dictionary form of `input_output_aliases=` is deprecated, but is still fully supported
+- `CAN_USE_TRITON` guard dropped due to obsolescence
+- test cases grew from 187 to 438
+
+
+# 0.4.0
+- Add support for Gluon kernels
+- Fix handling of `TRITON_CACHE_DIR` in line with the upstream treatment
+
+# 0.3.1
+- Improve in-out parameter handling, getting rid of mandatory aliased parameters in
+kernel's signature
+- Revamp and fix bugs to support `jax>=0.8.2`
+- Monkey-patch Triton's `HIPBackend` to get rid of unnecessary dependency on `torch`

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ print(add(x_val, y_val))
 print(jax.jit(add)(x_val, y_val))
 ```
 
-One could also use input-output parameters for kernels:
+Alternatively, use the `@jt.kernel` decorator, which captures `triton_call()`
+arguments in advance and allows use of the familiar Triton-native
+`kernel[grid](*args, **kwargs)` syntax. Here's how to use it to cache the kernel's
+input-output parameter specification:
 
 ```python
-
+@jt.kernel(input_output_aliases="y_inout_ptr")  # this tells triton_call() launcher that
+# argument of `y_inout_ptr` parameter is an in-out array
 @triton.jit
 def add_inplace_y_kernel(
     x_ptr,          # input vector
@@ -91,24 +95,89 @@ from functools import partial
 
 # jitting or jitting with donation isn't mandatory, but makes invocation more efficient.
 # Otherwise XLA would have to make a copy of each non-donated in-out argument before
-# calling a kernel, since JAX arrays by default are immutable.
+# calling a kernel, since JAX arrays are immutable by default.
 @partial(jax.jit, donate_argnames="y")
 def add_inplace_y(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
   block_size = 8
-  return jt.triton_call(
-      x,
-      y,            # explicit in-out argument
-      x.size,
-      kernel=add_inplace_y_kernel,
-      input_output_aliases={1: 0},  # input arg idx 1 (y) is the first output arg
-      out_shape=x,
-      grid=(x.size // block_size,),
-      block_size=block_size)
+  grid = x.size // block_size
+  return add_inplace_y_kernel[grid](x, y, x.size, out_shape=x, block_size=block_size)
 
 x_val = jnp.arange(8)
 y_val = jnp.arange(8, 16)
 print(add_inplace_y(x_val, y_val))
 ```
+
+Note that you can use advanced Triton features such as passing strings, tuples, and
+callables, for example:
+
+```python
+from jax import random
+import numpy as np
+from triton.language.extra import libdevice
+from typing import NamedTuple
+import time
+
+class Function(NamedTuple):
+  fn: tl.constexpr
+  captured: tuple
+
+@triton.jit
+def func1(x_ptr, y_ptr: tl.const, SIZE: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  x = tl.load(x_ptr + off)
+  y = tl.load(y_ptr + off)
+  x1 = libdevice.sin(x)
+  x2 = libdevice.cos(x)
+  z = x1 * x1 + x2 * x2
+  tl.store(x_ptr + off, z)
+  y = libdevice.asin(y) + libdevice.acos(y)
+  return z, libdevice.floor(2 * y)
+
+@triton.jit
+def floor_of_func(values, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  return libdevice.floor(getattr(libdevice, FUNC_NAME)(values))
+
+@triton.jit
+def aggregate(Ptrs):
+  z = tl.zeros([], tl.float32)
+  for i in tl.static_range(len(Ptrs)):
+    z += Ptrs[i]
+  return z
+
+@jt.kernel
+@triton.jit
+def kernel(capture, out_ptr, SIZE: tl.constexpr, FUNC_NAME: tl.constexpr):
+  off = tl.arange(0, SIZE)
+  t1, t2 = capture.fn(*capture.captured, SIZE=SIZE)
+  t3 = floor_of_func(t1, SIZE=SIZE, FUNC_NAME=FUNC_NAME)
+  t4 = t2 * t3
+  result = aggregate((t4, t4 * t4)).to(tl.int32)
+  tl.store(out_ptr + off, result)
+
+size = 8
+k1, k2 = random.split(random.key(time.perf_counter_ns()), 2)
+x = random.uniform(k1, (size,), dtype=jnp.float32)
+y = random.uniform(k2, (size,), dtype=jnp.float32)
+
+fn = Function(func1, (x, y))
+out, x = kernel[(1,)](
+  fn,  # essentially a tuple of (func_name, (2 arrays in a subtuple))
+  SIZE=size,
+  FUNC_NAME="exp",
+  out_shape=jnp.zeros(size, dtype=jnp.int32),
+  input_output_aliases=("capture", 1, 0),  # a path inside `capture` argument, 0th
+  # element of 1st subtuple, i.e. `x`. Note that since this is a tuple, it
+  # references just a single element (or all its embedded arrays if it's a tuple,
+  # but in this invocation it references array `x`)
+)
+np.testing.assert_array_equal(out, jnp.full((size,), 42, dtype=jnp.int32))
+assert out.dtype == jnp.int32
+np.testing.assert_allclose(x, jnp.full((size,), 1.0, dtype=jnp.float32), rtol=5e-7)
+assert x.dtype == jnp.float32
+```
+
+For detailed information on `triton_call()` parameters, refer to its docstring.
 
 See [the examples
 directory](https://github.com/jax-ml/jax-triton/tree/main/examples), especially
@@ -116,7 +185,7 @@ directory](https://github.com/jax-ml/jax-triton/tree/main/examples), especially
 and [the fused attention
 ipynb](https://github.com/jax-ml/jax-triton/blob/main/examples/JAX_%2B_Triton_Flash_Attention.ipynb).
 
-Some other use-cases are also covered in [tests](https://github.com/jax-ml/jax-triton/tree/main/tests).
+Many use cases are covered in [tests](https://github.com/jax-ml/jax-triton/tree/main/tests).
 
 ## Installation
 
@@ -129,7 +198,7 @@ Make sure you have a CUDA- or ROCm- compatible `jax` installed. For example you 
 $ pip install "jax[cuda12]"
 ```
 
-## Development
+## Development / Bleeding edge version
 
 To develop `jax-triton`, you can clone the repo with:
 ```bash
@@ -145,3 +214,28 @@ To run the `jax-triton` tests, you'll need `pytest`:
 $ pip install pytest
 $ pytest tests/
 ```
+
+## Known limitations (a non-exhaustive list)
+
+0. Due to JAX's custom call API restrictions, purely output parameters of a kernel
+should be defined last in the kernel's signature (ignoring `constexpr`s). Certain
+relaxations of this rule exist, but it's just simpler to always follow it by reordering
+kernel parameters.
+
+1. Be aware that a pattern benign in upstream Triton — pre-allocating an empty buffer
+and passing it as `jax-triton`'s input-output buffer to be only written to by the
+kernel — may incur a host-to-device data copy cost in JAX. Use purely output arguments
+instead.
+
+2. Autotuner / heuristics might have support gaps, for example: `Config.pre_hook` /
+`Config.post_hook` hooks aren't implemented; custom `do_bench` / `perf_model` /
+`early_config_prune` / `top_k` on `triton.autotune` might not behave correctly.
+
+3. Triton Python-runtime features, such as `JITFunction.warmup`, `.preload`,
+Interpreter mode, and others aren't supported.
+
+4. May not work well on systems with several different GPU models.
+
+5. JAX-level transformations, such as `jax.grad`, `jax.jvp`, and `jax.vjp`, aren't
+supported on kernels.
+

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -919,7 +919,6 @@ def make_kernel_params(
   grid,
   zeroed_outputs,
   configs: list[triton.Config],
-  operand_output_aliases: dict[int, int],
 ) -> list[dict[str, Any]]:
   """Make kernel call parameters for each config."""
   zeroed_outputs_callable = callable(zeroed_outputs)
@@ -943,14 +942,11 @@ def make_kernel_params(
       zeroed_outputs(config_metaparams) if zeroed_outputs_callable else zeroed_outputs
     )
 
-    # zeroed_params_with_sizes is a dict output_arg_idx -> aval_size_bytes
+    # zeroed_params_with_sizes is a dict raw_array_idx -> aval_size_bytes
     # config_zeroed_outputs contains output ordinal indices
-    output2input = {v: k for k, v in operand_output_aliases.items()}
     zeroed_params_with_sizes = {
-      output2input[i] if i in output2input else i + outputs_offset: aval_size_bytes(
-        ctx.avals_out[i]
-      )
-      for i in sorted(config_zeroed_outputs)
+      i + outputs_offset: aval_size_bytes(ctx.avals_out[i])
+      for i in config_zeroed_outputs
     }
 
     kernel_params.append(
@@ -1127,7 +1123,6 @@ def triton_kernel_call_lowering(
     grid,
     zeroed_outputs,
     configs,
-    operand_output_aliases,
   )
 
   kernel_calls = []

--- a/jax_triton/version.py
+++ b/jax_triton/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 4, 0)
+__version_info__ = (0, 5, 0)
 __version__ = ".".join(str(v) for v in __version_info__)

--- a/tests/zeroed_outputs_test.py
+++ b/tests/zeroed_outputs_test.py
@@ -1,0 +1,262 @@
+# Copyright 2026 The jax_triton Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional tests for zeroed_outputs= parameter of triton_call().
+
+Note that all these tests have an inherent weakness that could render them potentially
+useless should the backend behavior change: zeroing of purely output arguments is
+tricky, since when the backend initially allocates memory on a device, the memory comes
+from a driver always already zeroed due to security concerns. The tests are based on an
+observed backend behavior that if the same kernel is launched 2 times while the outputs
+of the first run are discarded, then on the next run the kernel's purely output argument
+will retain its old "dirty" values. If this behavior changes, the tests will become
+flaky.
+
+Previously the only test for zeroed_outputs= was based on zeroing an in-out argument.
+The problem with that is that zeroing in-out arguments doesn't seem to have any
+real-world use, since it just turns an in-out argument back into a purely output
+argument, all while likely still requiring the backend to copy the argument content from
+the host to a device before clearing it. This prevents any information from passing into
+the kernel via the aliased argument. Implementing that feature with proper support for
+tuples is cumbersome and is not worth the effort, considering it has no real-world use
+beyond testing.
+
+Unfortunately, I have no better ideas at this time on how to test this more robustly.
+"""
+
+import os
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import config, random
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+
+config.parse_flags_with_absl()
+
+
+ERR_MSG = (
+  "This test's assumption that subsequent calls use dirty buffers is "
+  "violated (likely because of the backend behavior change). This makes the test "
+  "either flaky or useless. Anyway, the test needs to be fixed and until that the "
+  "best possible solution is to disable/skip this test."
+)
+
+# large array is likely to be reallocated to the same memory
+ARRAY_SIZE = 100000
+
+
+@jt.kernel
+@triton.jit
+def zeroing_kernel(
+  x_ptr: tl.const,
+  n_elements,
+  out_ptr,
+  BLOCK_SIZE: tl.constexpr,
+  CLEANUP: tl.constexpr = False,  # this also implicitly tests defaults
+):
+  pid = tl.program_id(axis=0)
+  block_start = pid * BLOCK_SIZE
+  offsets = block_start + tl.arange(0, BLOCK_SIZE)
+  mask = offsets < n_elements
+  # explicit cleanup is needed to isolate the kernel from previous tests run history
+  if CLEANUP:
+    tl.store(out_ptr + offsets, 0, mask=mask)
+  x = tl.load(x_ptr + offsets, mask=mask)
+  y = tl.load(out_ptr + offsets, mask=mask)
+  output = x + y
+  tl.store(out_ptr + offsets, output, mask=mask)
+
+
+class TritonCallZeroedOutputsTest(parameterized.TestCase):
+  @parameterized.product(
+    use_function=[False, True], arg_form=[("out_ptr",), (2,), (("out_ptr",),), ((2,),)]
+  )
+  def test_arg_form_raw(self, use_function, arg_form):
+    x = random.normal(random.key(0), shape=ARRAY_SIZE)
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+
+    # first test the backend behavior, that sequential calls use dirty outputs.
+    out = zeroing_kernel[grid](
+      x, x.size, BLOCK_SIZE=BLOCK_SIZE, CLEANUP=True, out_shape=x
+    )
+    np.testing.assert_allclose(out, x)
+    del out
+
+    # verify the core test assumption that the second call uses a dirty buffer
+    out = zeroing_kernel[grid](x, x.size, BLOCK_SIZE=BLOCK_SIZE, out_shape=x)
+    np.testing.assert_allclose(out, 2 * x, err_msg=ERR_MSG)
+    del out
+
+    # finally test zeroed_outputs
+    zeroed_arg = (lambda x: arg_form) if use_function else arg_form
+    out = zeroing_kernel[grid](
+      x, x.size, BLOCK_SIZE=BLOCK_SIZE, out_shape=x, zeroed_outputs=zeroed_arg
+    )
+    np.testing.assert_allclose(out, x)
+
+  @parameterized.product(
+    use_function=[False, True],
+    zeroed_which=[
+      # (zeroed_spec, which_zeroed) — which_zeroed tells us which tuple elements to expect zeroed
+      (("out_ptrs", 0), {0}),  # string + sub-index, zero first only
+      (("out_ptrs", 1), {1}),  # string + sub-index, zero second only
+      ((2, 0), {0}),  # int + sub-index, zero first only
+      ((2, 1), {1}),  # int + sub-index, zero second only
+      ("out_ptrs", {0, 1}),  # string, zero both
+      ((("out_ptrs", 0), ("out_ptrs", 1)), {0, 1}),  # tuples, zero both
+      ((("out_ptrs", 1), ("out_ptrs", 0)), {0, 1}),  # tuples, zero both
+      (2, {0, 1}),  # int, zero both
+      (((2, 0), (2, 1)), {0, 1}),  # tuples, zero both
+      (((2, 1), (2, 0)), {0, 1}),  # tuples, zero both
+      (((2, 1), ("out_ptrs", 0)), {0, 1}),  # tuples, zero both
+      ((("out_ptrs", 1), (2, 0)), {0, 1}),  # tuples, zero both
+    ],
+  )
+  def test_tuple(self, use_function, zeroed_which):
+    """zeroed_outputs uses a tuple path to address a single array inside a
+    compound (tuple) output parameter."""
+    zeroed_spec, which_zeroed = zeroed_which
+
+    @jt.kernel(out_names="out_ptrs")
+    @triton.jit
+    def kernel_tuple_path(
+      x_ptr: tl.const,
+      n_elements,
+      out_ptrs,
+      BLOCK_SIZE: tl.constexpr,
+      CLEANUP: tl.constexpr = False,
+    ):
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      for i in tl.static_range(len(out_ptrs)):
+        if CLEANUP:
+          tl.store(out_ptrs[i] + offsets, 0, mask=mask)
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(out_ptrs[i] + offsets, mask=mask)
+        tl.store(out_ptrs[i] + offsets, x + y, mask=mask)
+
+    x = random.normal(random.key(20), shape=(ARRAY_SIZE,))
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+    z = jax.ShapeDtypeStruct(x.shape, x.dtype)
+    shape_pair = (z, z)
+
+    args = [x, x.size]
+    kwargs = dict(BLOCK_SIZE=BLOCK_SIZE, out_shape=[shape_pair])
+
+    # prime
+    o0, o1 = kernel_tuple_path[grid](*args, **kwargs, CLEANUP=True)
+    np.testing.assert_allclose(o0, x)
+    np.testing.assert_allclose(o1, x)
+    del o0, o1
+    # confirm dirty
+    o0, o1 = kernel_tuple_path[grid](*args, **kwargs)
+    np.testing.assert_allclose(o0, 2 * x, err_msg=ERR_MSG)
+    np.testing.assert_allclose(o1, 2 * x, err_msg=ERR_MSG)
+    del o0, o1
+
+    # selective zeroing via tuple path
+    zeroed_outputs = (
+      (zeroed_spec,)
+      if not isinstance(zeroed_spec, tuple) or not isinstance(zeroed_spec[0], tuple)
+      else zeroed_spec
+    )
+    o0, o1 = kernel_tuple_path[grid](
+      *args,
+      **kwargs,
+      zeroed_outputs=(lambda x: zeroed_outputs) if use_function else zeroed_outputs,
+    )
+    for i, out in enumerate((o0, o1)):
+      if i in which_zeroed:
+        np.testing.assert_allclose(out, x, err_msg=f"out_ptrs[{i}] should be zeroed")
+      else:
+        np.testing.assert_allclose(
+          out, 3 * x, err_msg=f"out_ptrs[{i}] should NOT be zeroed"
+        )
+
+  @parameterized.parameters(True, False)
+  def test_config_dependent_callable(self, zero_first):
+    """Callable that inspects a constexpr metaparam to decide which output to zero.
+    Also tests that modification of kwargs in callable is propagated."""
+
+    @jt.kernel(out_names=("out0_ptr", "out1_ptr"))
+    @triton.jit
+    def kernel_configurable(
+      x_ptr: tl.const,
+      n_elements,
+      out0_ptr,
+      out1_ptr,
+      BLOCK_SIZE: tl.constexpr,
+      CLEANUP: tl.constexpr = False,
+    ):
+      pid = tl.program_id(axis=0)
+      block_start = pid * BLOCK_SIZE
+      offsets = block_start + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < n_elements
+      if CLEANUP:
+        tl.store(out0_ptr + offsets, 0, mask=mask)
+        tl.store(out1_ptr + offsets, 0, mask=mask)
+      x = tl.load(x_ptr + offsets, mask=mask)
+      o0 = tl.load(out0_ptr + offsets, mask=mask)
+      o1 = tl.load(out1_ptr + offsets, mask=mask)
+      tl.store(out0_ptr + offsets, x + o0, mask=mask)
+      tl.store(out1_ptr + offsets, x + o1, mask=mask)
+
+    x = random.normal(random.key(50), shape=(ARRAY_SIZE,))
+    BLOCK_SIZE = 8
+    grid = triton.cdiv(x.size, BLOCK_SIZE)
+    args = [x, x.size]
+    kwargs = dict(BLOCK_SIZE=BLOCK_SIZE, out_shape=(x, x))
+
+    # The callable inspects the WHICH constexpr from metaparams
+    def zeroed_fn(meta):
+      which_val = meta["WHICH"]
+      del meta["WHICH"]  # also tests that modification of kwargs is propagated
+      return ("out0_ptr",) if which_val == 0 else ("out1_ptr",)
+
+    # prime both outputs to a dirty state
+    o0, o1 = kernel_configurable[grid](*args, **kwargs, CLEANUP=True)
+    np.testing.assert_allclose(o0, x)
+    np.testing.assert_allclose(o1, x)
+    del o0, o1
+    o0, o1 = kernel_configurable[grid](*args, **kwargs)
+    np.testing.assert_allclose(o0, 2 * x, err_msg=ERR_MSG)
+    np.testing.assert_allclose(o1, 2 * x, err_msg=ERR_MSG)
+    del o0, o1
+
+    # WHICH=0 - callable zeros out0_ptr; WHICH=1 - callable zeros out1_ptr
+    which_val = 0 if zero_first else 1
+    o0, o1 = kernel_configurable[grid](
+      *args, **kwargs, WHICH=which_val, zeroed_outputs=zeroed_fn
+    )
+
+    if zero_first:
+      np.testing.assert_allclose(o0, x, err_msg="out0 should be zeroed (WHICH=0)")
+      np.testing.assert_allclose(o1, 3 * x, err_msg="out1 should be dirty (WHICH=0)")
+    else:
+      np.testing.assert_allclose(o0, 3 * x, err_msg="out0 should be dirty (WHICH=1)")
+      np.testing.assert_allclose(o1, x, err_msg="out1 should be zeroed (WHICH=1)")
+
+
+if __name__ == "__main__":
+  os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"
+  absltest.main()


### PR DESCRIPTION
…zeroed_outputs

Finalize the previous 3 PRs with the 0.5.0 release of jax-triton.

This PR contains:

Behavior change (breaking): `triton_call(..., zeroed_outputs=...)` no longer supports zeroing of input-output aliased arguments. The `operand_output_aliases` remapping in the lowering helper that built `zeroed_params_with_sizes` is removed; the set of indices is now interpreted directly as output indices (offset by `outputs_offset`), and the `operand_output_aliases` argument is dropped from that helper and its call site. Callers that previously relied on naming an aliased input through `zeroed_outputs` must zero those buffers explicitly or use a non-aliased output instead.

Tests: add `tests/zeroed_outputs_test.py` (262 lines) covering the new, narrower contract of `zeroed_outputs=`.

Docs: rework the README's input-output example to use the `@jt.kernel` decorator together with the Triton-native `kernel[grid](*args, **kwargs)` launch syntax, and add an advanced example demonstrating `NamedTuple` captures, `tl.constexpr` callables/strings, and a tuple-path `input_output_aliases=("capture", 1, 0)`. Add a "Known limitations" section listing constraints on output-parameter ordering, the cost of empty-buffer-as-input patterns, gaps in autotuner/heuristics support, unsupported Triton Python-runtime features (`warmup`, `preload`, Interpreter mode), multi-GPU-model caveats, and the lack of `jax.grad` / `jvp` / `vjp` on kernels.

Add `CHANGELOG.md` summarizing the full 0.5.0 release and bump `__version_info__` from `(0, 4, 0)` to `(0, 5, 0)`.