### PR TITLE
0.5.1 Fix compilation pipelines to compile Gluon properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1
+## Bugfixes
+- Gluon wasn't compiled using correct compilation pipeline, so the compilation pipelines
+for both dialects were reworked to delegate pipeline construction to the upstream Triton
+
 # 0.5.0
 ## Breaking changes
 - `float` now follows upstream convention and is represented as `fp32`, instead of the

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -16,7 +16,6 @@
 
 from collections.abc import Callable, Sequence
 import copy
-import dataclasses
 import functools
 from functools import cached_property
 import inspect
@@ -78,23 +77,23 @@ InOutSpec = int | str | KernelArgPath | tuple[int | str | KernelArgPath, ...]
 _TMEM_MAX_SIZE = 512
 
 _JAX_TO_TRITON_TYPE_MAP = {
-    jnp.dtype("bfloat16"): "bf16",
-    jnp.dtype("float64"): "fp64",
-    jnp.dtype("float32"): "fp32",
-    jnp.dtype("float16"): "fp16",
-    jnp.dtype("float8_e4m3fn"): "fp8e4nv",
-    jnp.dtype("float8_e5m2"): "fp8e5",
-    jnp.dtype("float8_e4m3fnuz"): "fp8e4b8",
-    jnp.dtype("float8_e5m2fnuz"): "fp8e5b16",
-    jnp.dtype("int64"): "i64",
-    jnp.dtype("int32"): "i32",
-    jnp.dtype("int16"): "i16",
-    jnp.dtype("int8"): "i8",
-    jnp.dtype("uint64"): "u64",
-    jnp.dtype("uint32"): "u32",
-    jnp.dtype("uint16"): "u16",
-    jnp.dtype("uint8"): "u8",
-    jnp.dtype("bool"): "i1",
+  jnp.dtype("bfloat16"): "bf16",
+  jnp.dtype("float64"): "fp64",
+  jnp.dtype("float32"): "fp32",
+  jnp.dtype("float16"): "fp16",
+  jnp.dtype("float8_e4m3fn"): "fp8e4nv",
+  jnp.dtype("float8_e5m2"): "fp8e5",
+  jnp.dtype("float8_e4m3fnuz"): "fp8e4b8",
+  jnp.dtype("float8_e5m2fnuz"): "fp8e5b16",
+  jnp.dtype("int64"): "i64",
+  jnp.dtype("int32"): "i32",
+  jnp.dtype("int16"): "i16",
+  jnp.dtype("int8"): "i8",
+  jnp.dtype("uint64"): "u64",
+  jnp.dtype("uint32"): "u32",
+  jnp.dtype("uint16"): "u16",
+  jnp.dtype("uint8"): "u8",
+  jnp.dtype("bool"): "i1",
 }
 
 
@@ -173,7 +172,7 @@ def avals_to_layouts(avals):
 triton_kernel_call_p = jex.core.Primitive("triton_kernel_call")
 triton_kernel_call_p.multiple_results = True
 triton_kernel_call_p.def_impl(
-    functools.partial(xla.apply_primitive, triton_kernel_call_p)
+  functools.partial(xla.apply_primitive, triton_kernel_call_p)
 )
 
 
@@ -193,6 +192,8 @@ def make_gpu_target_cuda(device, compute_capability):
 
 
 _IS_HIPBackend_PATCHED = False
+
+
 def _patch_hip_backend():
   """
   This fixes unconditional and totally unnecessary "import torch" in Triton's
@@ -233,146 +234,96 @@ def make_gpu_target_hip(device, compute_capability):
   return hb.GPUTarget("hip", arch, 64)
 
 
-@dataclasses.dataclass
 class CompilationResult:
-  binary: str
-  name: str
-  shared_mem_bytes: int
-  ttgir: str | None
-  llir: str | None
+  def __init__(
+    self,
+    src: tc.ASTSource | gl_runtime.GluonASTSource,
+    module,
+    gpu_target: cb.GPUTarget | hb.GPUTarget,
+    backend: cb.CUDABackend | hb.HIPBackend,
+    options: cb.CUDAOptions | hb.HIPOptions,
+    platform: str,
+  ):
+    # We don't need special `compute_capability` instance here, since Triton stores it
+    # in a gpu_target object and NVIDIA's backend uses it to properly set options.arch
+    # in the backend.parse_options(), which instantiates the options object.
 
+    is_cuda = platform == "cuda"
+    is_rocm = platform == "rocm"
 
-def compile_ttir_inplace(
-    ttir,
-    backend: [cb.CUDABackend | hb.HIPBackend],
-    options: [cb.CUDAOptions | hb.HIPOptions],
-    compute_capability,
-    platform,
-):
-  if platform == "cuda":
-    return compile_ttir_to_ptx_inplace(
-        ttir,
-        backend,
-        options,
-        compute_capability,
-    )
+    debug = options.debug
+    if debug:
+      print("Compilation, initial module:", module)
 
-  elif platform == "rocm":
-    return compile_ttir_to_hsaco_inplace(
-        ttir,
-        backend,
-        options,
-        compute_capability,
-    )
-  else:
-    raise ValueError("Unsupported device.")
+    metadata = {
+      "target": gpu_target,
+      **options.__dict__,
+      "triton_version": triton.__version__,
+    }
 
+    stages = {}
+    backend.add_stages(stages, options, src.language)
 
-def compile_ttir_to_ptx_inplace(
-    ttir,
-    cuda_backend: cb.CUDABackend,
-    cuda_options: cb.CUDAOptions,
-    compute_capability,
-) -> CompilationResult:
-  if cuda_options.debug:
-    print(ttir)
-  try:
-    metadata = {}
-    opt_ttir = cuda_backend.make_ttir(ttir, metadata, cuda_options, compute_capability)
-    ttgir = cuda_backend.make_ttgir(
-        opt_ttir,
-        metadata,
-        cuda_options,
-        compute_capability,
-    )
-  except RuntimeError as e:
-    ttir.dump()
-    raise ValueError("TTIR->TTGIR pass failed!") from e
-  if cuda_options.debug:
-    print(ttgir)
-  try:
-    llir = cuda_backend.make_llir(
-        ttgir,
-        metadata,
-        cuda_options,
-        compute_capability,
-    )
-  except RuntimeError as e:
-    ttgir.dump()
-    raise ValueError("TTGIR->LLIR pass failed!") from e
-  if metadata["tmem_size"] > _TMEM_MAX_SIZE:
-    raise ValueError(
-        f"TMEM size {metadata['tmem_size']} exceeds limit {_TMEM_MAX_SIZE}."
-    )
-  shared_mem_bytes = metadata["shared"]
-  if cuda_options.debug:
-    print(llir)
-  ptx = cuda_backend.make_ptx(
-      llir,
-      metadata,
-      cuda_options,
-      compute_capability,
-  )
-  if cuda_options.debug:
-    print(ptx)
-  name = metadata["name"]
-  ttgir = str(ttgir) if _JAX_TRITON_DUMP_DIR else None
-  llir = str(llir) if _JAX_TRITON_DUMP_DIR else None
-  return CompilationResult(
-      binary=ptx,
-      name=name,
-      shared_mem_bytes=shared_mem_bytes,
-      ttgir=ttgir,
-      llir=llir,
-  )
+    # verify the pipeline ends on stages we expect to safeguard against unexpected
+    # upstream changes
+    stage_seq = tuple(stages.keys())
+    assert len(stage_seq) > 2
+    if is_cuda:
+      assert stage_seq[-1] == "cubin" and stage_seq[-2] == "ptx"
+      # we don't need the `cubin` stage
+      stages.pop("cubin", None)
+    elif is_rocm:
+      assert stage_seq[-1] == "hsaco"
+    else:
+      raise ValueError("Unsupported platform.")
 
+    shared_mem_bytes = None
+    # Unfortunately, we can't save individual stage results without making expensive
+    # copies of module object, so instead we save only the results we really need
+    ttgir = None
+    llir = None
+    try:
+      prev_stage = None
+      for stage, compile_ir in stages.items():
+        next_module = compile_ir(module, metadata)
+        if debug:
+          print(f"Compilation, after stage={stage}:", next_module)
 
-def compile_ttir_to_hsaco_inplace(
-    ttir,
-    hip_backend: hb.HIPBackend,
-    hip_options: hb.HIPOptions,
-    compute_capability,
-) -> CompilationResult:
-  if hip_options.debug:
-    print(ttir)
-  try:
-    metadata = {}
-    opt_ttir = hip_backend.make_ttir(ttir, metadata, hip_options)
-    ttgir = hip_backend.make_ttgir(opt_ttir, metadata, hip_options)
-  except RuntimeError as e:
-    ttir.dump()
-    raise ValueError("TTIR->TTGIR pass failed!") from e
-  if hip_options.debug:
-    print(ttgir)
-  try:
-    llir = hip_backend.make_llir(ttgir, metadata, hip_options)
-  except RuntimeError as e:
-    ttgir.dump()
-    raise ValueError("TTGIR->LLIR pass failed!") from e
-  shared_mem_bytes = metadata["shared"]
-  if hip_options.debug:
-    print(llir)
+        if stage == "llir":
+          if is_cuda and metadata["tmem_size"] > _TMEM_MAX_SIZE:
+            raise ValueError(
+              f"TMEM size {metadata['tmem_size']} exceeds limit {_TMEM_MAX_SIZE}."
+            )
+          shared_mem_bytes = metadata["shared"]
+          if _JAX_TRITON_DUMP_DIR:
+            llir = str(next_module)
+        elif bool(_JAX_TRITON_DUMP_DIR) and stage == "ttgir":
+          ttgir = str(next_module)
 
-  amdgcn = hip_backend.make_amdgcn(llir, metadata, hip_options)
-  hsaco = hip_backend.make_hsaco(amdgcn, metadata, hip_options)
+        module = next_module
+        prev_stage = stage
 
-  name = metadata["name"]
-  ttgir = str(ttgir) if _JAX_TRITON_DUMP_DIR else None
-  llir = str(llir) if _JAX_TRITON_DUMP_DIR else None
-  # Instead of passing hsaco which are "bytes", we first write
-  # to a file and then pass the "string" path. This is needed because
-  # nanobind doesn't automatically convert between bytes and string.
-  # https://github.com/wjakob/nanobind/discussions/137
-  fd, hsaco_path = tempfile.mkstemp()
-  with os.fdopen(fd, "wb") as f:
-    f.write(hsaco)
-  return CompilationResult(
-      binary=hsaco_path,
-      name=name,
-      shared_mem_bytes=shared_mem_bytes,
-      ttgir=ttgir,
-      llir=llir,
-  )
+    except RuntimeError as e:
+      module.dump()
+      raise ValueError(f"{prev_stage}->{stage} pass failed!") from e
+
+    assert shared_mem_bytes is not None
+
+    if is_rocm:
+      # Instead of passing hsaco which are "bytes", we first write
+      # to a file and then pass the "string" path. This is needed because
+      # nanobind doesn't automatically convert between bytes and string.
+      # https://github.com/wjakob/nanobind/discussions/137
+      fd, hsaco_path = tempfile.mkstemp()
+      with os.fdopen(fd, "wb") as f:
+        f.write(module)
+      module = hsaco_path
+
+    self.name = metadata["name"]
+    self.ttgir = ttgir
+    self.llir = llir
+    self.shared_mem_bytes = shared_mem_bytes
+    self.binary = module
 
 
 def make_backend(
@@ -635,6 +586,10 @@ class JTJITFunction:
     """
     return self.fn._jT_asm if hasattr(self.fn, "_jT_asm") else None
 
+  def clean_asm(self):
+    if hasattr(self.fn, "_jT_asm"):
+      self.fn._jT_asm = {}
+
   @property
   def compiled_kernels_cache_size(self) -> int:
     return len(self.fn._jT_kernel_cache) if hasattr(self.fn, "_jT_kernel_cache") else 0
@@ -801,9 +756,10 @@ class JTJITFunction:
       codegen_fns = backend.get_codegen_implementation(backend_options)
 
       real_ASTSource = gl_runtime.GluonASTSource if self.is_gluon else tc.ASTSource
-      module = real_ASTSource(
+      source = real_ASTSource(
         self.fn, constexprs=constexprs, signature=signature, attrs=attrs
-      ).make_ir(
+      )
+      module = source.make_ir(
         gpu_target, backend_options, codegen_fns, backend.get_module_map(), context
       )
 
@@ -812,8 +768,13 @@ class JTJITFunction:
       # triton_kernel_call_lib.TritonKernel() stores ttir internally, but does not
       # expose access to it, so we store it manually elsewhere for testing purposes.
 
-      compilation_result = compile_ttir_inplace(
-        module, backend, backend_options, compute_capability, platform
+      compilation_result = CompilationResult(
+        source,
+        module,
+        gpu_target,
+        backend,
+        backend_options,
+        platform,
       )
 
       kernel_name = compilation_result.name
@@ -1258,9 +1219,13 @@ class JTArray:
 
   def __init__(self, aval, idx: int):
     self.dtype = get_type_id(aval)
-    self.index = idx  # index into a corresponding avals array.
+    self.index = idx  # index into a corresponding avals arrays.
     # TODO(sharadmv,zhangqiaorjc): handle differently aligned pointers
     self.data_ptr = lambda: JTArray._default_alignment
+    size = aval_size_bytes(aval)
+    # ptr_range() is mandatory on AMD to trigger correct return from
+    # HIPBackend.is_within_2gb() which is an important precondition for vectorized ops
+    self.ptr_range = lambda: size
 
 
 def serialize_args_kwargs(jtfu, args, kwargs):

--- a/jax_triton/version.py
+++ b/jax_triton/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version_info__ = (0, 5, 0)
+__version_info__ = (0, 5, 1)
 __version__ = ".".join(str(v) for v in __version_info__)

--- a/tests/gluon_test.py
+++ b/tests/gluon_test.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 from jax import config
 from jax import random
 import jax_triton as jt
+import jax_triton.triton_lib as jttl
 import numpy as np
 import triton
 
@@ -91,19 +92,40 @@ def memcpy_inplace_output_kernel(in_ptr, out_ptr, xnumel, XBLOCK: gl.constexpr):
 class GluonTest(parameterized.TestCase):
   @parameterized.product(dtype=_JAX_DTYPES)
   def test_copy_scalar_kernel(self, dtype):
+    # this also tests if HIPBackend.is_within_2gb() works correctly on AMD.
+    # Might be wrong, but looks like NVIDIA doesn't have anything similar to that and
+    # it's compiler don't even override `get_tensor_specialization()` which on AMD adds
+    # "S" attribute based on is_within_2gb() output.
+
+    # We need the platform ID, and I didn't find a better way than this ugliness
+    backends = jax.extend.backend.backends()
+    default = jax.extend.backend.get_backend()
+    name = next((n for n, c in backends.items() if c is default))
+    is_rocm = name == "rocm"
+
     def copy_scalar(input: jnp.ndarray) -> jnp.ndarray:
       assert input.size == 1 and input.ndim == 0
-      # note, this also checks behaviour in the absence of metaparams args.
       return jt.triton_call(
         input,
         kernel=copy_scalar_kernel,
-        out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
+        out_shape=input,
         grid=1,
+        _store_asm=is_rocm,
       )
 
     input = jnp.array(42.314, dtype=dtype)
     output = copy_scalar(input)
     np.testing.assert_equal(output, input)
+
+    if is_rocm:
+      jtkernel = jttl.JTJITFunction(copy_scalar_kernel)
+      asm = jtkernel.asm
+      assert len(asm) == 1
+      ttir = next(iter(asm.values())).get("ttir")
+      assert ttir.count("tt.pointer_range = 32 : i32") == 2, (
+        "Expected that each array argument has a pointer_range attribute"
+      )
+      jtkernel.clean_asm()
 
   @parameterized.product(XBLOCK=[64], xnumel=[40, 500, 16 * 1024 + 1])
   def test_memcpy(self, XBLOCK, xnumel):

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -592,15 +592,14 @@ class TritonKernelCallTest(parameterized.TestCase):
     x1, y1 = create_random_inputs([42])
     x2, y2 = create_random_inputs([43])
 
-    compile_ttir_inplace = jttl.compile_ttir_inplace
-
     call_count = [0]
 
-    def my_compile(*args, **kwargs):
-      call_count[0] += 1
-      return compile_ttir_inplace(*args, **kwargs)
+    class MyCompilationResult(jttl.CompilationResult):
+      def __init__(self, *args, **kwargs):
+        call_count[0] += 1
+        super().__init__(*args, **kwargs)
 
-    with mock.patch.object(jttl, "compile_ttir_inplace", new=my_compile):
+    with mock.patch.object(jttl, "CompilationResult", new=MyCompilationResult):
       _ = fn1(x1, y1)
       self.assertEqual(call_count[0], 1)
       self.assertEqual(jt_cache_size(), 1)


### PR DESCRIPTION
## Motivation

Gluon wasn't compiled using correct compilation pipeline, so the compilation pipelines
for both dialects were reworked to delegate pipeline construction to the upstream Triton

## Test Result

All 437 tests on AMD platform PASSED