### PR TITLE
[CI] Add check for `.github` modification by a sync PR + sync job 3h earlier

### DIFF
--- a/.github/workflows/amd-sync-upstream2.yml
+++ b/.github/workflows/amd-sync-upstream2.yml
@@ -120,7 +120,7 @@ on:
   schedule:
     # Daily (UTC). Note: GitHub may delay scheduled runs under load,
     # and auto-disables schedules after ~60 days of repository inactivity.
-    - cron: '34 8 * * *'
+    - cron: '34 5 * * *'
   workflow_dispatch:
 
 # Never run two syncs at once; let an in-flight run finish rather than cancel it.

--- a/.github/workflows/amd-sync-verify-merge.yml
+++ b/.github/workflows/amd-sync-verify-merge.yml
@@ -3,28 +3,44 @@
 # =============================================================================
 #
 # PURPOSE
-#   Verify that every merged sync PR (head branch under `z_automation/upstream-sync/`,
-#   produced by amd-sync-upstream2.yml) was merged with a strategy that PRESERVES
-#   commit ancestry - i.e. "Create a merge commit" (a plain fast-forward also
-#   preserves it). "Squash and merge" and "Rebase and merge" rewrite/collapse the
-#   upstream commits into brand-new SHAs, so the original commits stop being
-#   ancestors of the base branch. That breaks the incremental detection in
-#   amd-sync-upstream2.yml (its `git merge-base --is-ancestor` fast path and its
-#   merge-base computation), causing redundant re-merges, spurious conflicts, and
-#   duplicate sync PRs.
+#   Verify two invariants for every merged sync PR (head branch under
+#   `z_automation/upstream-sync/`, produced by amd-sync-upstream2.yml):
 #
-# HOW IT DETECTS (directly tests the invariant, instead of guessing the method)
-#   After a sync PR is merged, the PR's head commit (`head.sha`) MUST be an
-#   ancestor of the (post-merge) base branch tip:
-#     * merge commit -> head.sha is the merge's 2nd parent -> ancestor      (OK)
-#     * fast-forward -> head.sha IS the new base tip        -> ancestor      (OK)
-#     * squash       -> a new 1-parent commit               -> NOT ancestor  (BAD)
-#     * rebase       -> replayed commits with new SHAs       -> NOT ancestor  (BAD)
+#   1. ANCESTRY-PRESERVING MERGE. The PR was merged with a strategy that PRESERVES
+#      commit ancestry - i.e. "Create a merge commit" (a plain fast-forward also
+#      preserves it). "Squash and merge" and "Rebase and merge" rewrite/collapse
+#      the upstream commits into brand-new SHAs, so the original commits stop being
+#      ancestors of the base branch. That breaks the incremental detection in
+#      amd-sync-upstream2.yml (its `git merge-base --is-ancestor` fast path and its
+#      merge-base computation), causing redundant re-merges, spurious conflicts,
+#      and duplicate sync PRs.
+#
+#   2. NO `.github/` MODIFICATION. The merge changed nothing under `.github/`. The
+#      base branch owns its own `.github/`, and every sync branch pins `.github/`
+#      to the base (see amd-sync-upstream2.yml), so a sync merge MUST be a no-op
+#      there. A non-empty `.github/` delta means the upstream `.github/` leaked in -
+#      typically through a manual conflict resolution that let the upstream side
+#      win under `.github/`.
+#
+# HOW IT DETECTS (directly tests the invariants, instead of guessing the method)
+#   1. ANCESTRY: after a sync PR is merged, the PR's head commit (`head.sha`) MUST
+#      be an ancestor of the (post-merge) base branch tip:
+#        * merge commit -> head.sha is the merge's 2nd parent -> ancestor      (OK)
+#        * fast-forward -> head.sha IS the new base tip        -> ancestor      (OK)
+#        * squash       -> a new 1-parent commit               -> NOT ancestor  (BAD)
+#        * rebase       -> replayed commits with new SHAs       -> NOT ancestor  (BAD)
+#   2. `.github/`: `HEAD^1..HEAD` restricted to `.github/` is exactly what merging
+#      this PR changed there (for the sanctioned merge commit, HEAD^1 is the base
+#      tip just before the merge; for a fast-forward, HEAD is the PR's own merge
+#      commit and HEAD^1 is likewise its pre-merge base). A non-empty diff is BAD.
+#      This check is meaningful for the ancestry-preserving merges that check 1
+#      enforces; it runs only after check 1 passes.
 #
 # WHAT IT DOES ON A BAD MERGE
-#   Fails the run and opens (or comments on) a tracking issue. It does NOT
-#   auto-revert: reverting a merge on a shared integration branch is destructive
-#   and easy to get wrong, so that is intentionally left to a maintainer.
+#   Fails the run and opens (or comments on) a tracking issue (a distinct issue
+#   per invariant, de-duplicated by title). It does NOT auto-revert: reverting a
+#   merge on a shared integration branch is destructive and easy to get wrong, so
+#   that is intentionally left to a maintainer.
 #
 # NOTES / ASSUMPTIONS
 #   * Uses `pull_request_target` so the workflow definition and token come from
@@ -137,4 +153,78 @@ jobs:
           fi
 
           # Fail the run so the bad merge is visible in checks/notifications.
+          exit 1
+
+      # -----------------------------------------------------------------------
+      # Guard: a sync PR must NEVER modify `.github/`. `${BASE_REF}` owns its own
+      # `.github/`, and every sync branch pins `.github/` to the base, so merging
+      # a sync PR must be a no-op there. A non-empty `.github/` delta means upstream
+      # `.github/` leaked in - typically via a manual conflict resolution that let
+      # the upstream side win under `.github/`.
+      # -----------------------------------------------------------------------
+      - name: Verify the merge did not modify .github
+        run: |
+          set -euo pipefail
+
+          # The sanctioned merge is a merge commit (asserted by the step above)
+          # whose first parent is the base tip immediately BEFORE this merge; for a
+          # fast-forward, HEAD is the PR's own merge commit and HEAD^1 is likewise
+          # its pre-merge base. Either way, HEAD^1..HEAD is exactly what merging
+          # this PR changed on `${BASE_REF}`, so restricting it to `.github`
+          # reveals any leak.
+          if ! CHANGED_GITHUB="$(git diff --name-only HEAD^1 HEAD -- .github)"; then
+            echo "::error title=.github guard failed::Could not compute the .github diff for PR #${PR_NUMBER}."
+            exit 1
+          fi
+
+          if [ -z "$CHANGED_GITHUB" ]; then
+            echo "OK: PR #${PR_NUMBER} introduced no changes under .github/."
+            exit 0
+          fi
+
+          echo "::error title=.github modified by sync PR::PR #${PR_NUMBER} changed files under .github/, which is not permitted for sync PRs."
+          echo "Changed paths under .github/:"
+          printf '%s\n' "$CHANGED_GITHUB"
+
+          TITLE="Sync PR #${PR_NUMBER} modified .github/ (not permitted)"
+
+          BODY_FILE="$(mktemp)"
+          {
+            echo "**PR #${PR_NUMBER}** (\`${PR_TITLE}\`) was merged into \`${BASE_REF}\` but it"
+            echo "**modified files under \`.github/\`**:"
+            echo
+            echo '```'
+            printf '%s\n' "$CHANGED_GITHUB"
+            echo '```'
+            echo
+            echo "Modification of \`.github\` directory is NOT permitted for synchronization"
+            echo "PRs. If you only tried to improve existing CI files, use a separate PR for that."
+            echo
+            echo "\`${BASE_REF}\` owns its \`.github/\` directory and every sync branch pins it to"
+            echo "the base, so a sync merge must be a no-op there. A non-empty delta usually"
+            echo "means a manual conflict resolution accidentally let the upstream \`.github/\`"
+            echo "side leak in (see \`.github/workflows/amd-sync-upstream2.yml\`)."
+            echo
+            echo "### Possible fixes"
+            echo "- Restore \`.github/\` on \`${BASE_REF}\` to its pre-merge state, or"
+            echo "- Open a separate, dedicated PR for any intended CI changes."
+          } > "$BODY_FILE"
+
+          # De-duplicate: if an open issue with this exact title already exists,
+          # comment on it; otherwise create a new one. Never let a failure here
+          # swallow the non-zero exit below.
+          EXISTING="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
+            --json number,title 2>/dev/null \
+            | jq -r --arg t "$TITLE" 'map(select(.title == $t)) | .[0].number // empty' || true)"
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Re-detected: PR #${PR_NUMBER} modified .github/ on ${BASE_REF}." \
+              || echo "warning: could not comment on issue #${EXISTING}"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE" \
+              || echo "warning: could not create tracking issue"
+          fi
+
+          # Fail the run so the .github leak is visible in checks/notifications.
           exit 1


### PR DESCRIPTION
## Motivation

Manual conflict resolution is prone to accidentally leaking the `.github` content from the upstream. This CI check adds a guard against that.

The sync job was scheduled too late for my TZ, rescheduling it 3h earlier so it's ready by the start of a work day.