### PR TITLE
Initialize ROCm CI workflow

### DIFF
--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -1,6 +1,9 @@
 name: CI ROCm
 
 on:
+  push:
+    branches:
+      - amd-main
   pull_request:
     branches:
       - amd-main
@@ -17,6 +20,6 @@ jobs:
     runs-on: linux-jax-triton-mi350-1
 
     steps:
-      - name: Verify workflow run
-        run: echo "CI ROCm"
+      - name:  Verify ROCm runner
+        run: rocminfo
 

--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -1,0 +1,22 @@
+name: CI ROCm
+
+on:
+  pull_request:
+    branches:
+      - amd-main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: linux-jax-triton-mi350-1
+
+    steps:
+      - name: Verify workflow run
+        run: echo "CI ROCm"
+


### PR DESCRIPTION
This PR adds an initial ROCm CI workflow. The current workflow is intentionally minimal and is only meant to verify that the workflow is triggered and runs on the ROCm runner. Follow-up PR will be added for JAX installation & test run.