### PR TITLE
Add AMD-specific directory with tests and benchmarks

### DIFF
--- a/AMD/README.md
+++ b/AMD/README.md
@@ -1,0 +1,3 @@
+This directory is a home for AMD specific tests, most if not all of which are also GPU-architecture specific.
+
+Note that for running benchmarks you would need to `pip install benchstats` first.

--- a/AMD/_aiter.py
+++ b/AMD/_aiter.py
@@ -1,0 +1,323 @@
+"""supplemental code from aiter to alleviate porting kernel tests."""
+# based on https://github.com/ROCm/aiter/blob/7411c99753f0661a3eecdbdb1b36feb58539f62b
+
+import json
+import functools
+import os
+
+import jax.numpy as jnp
+import triton
+import triton.language as tl
+
+import arch_info
+
+
+AITER_TRITON_CONFIGS_PATH: str | None = None
+
+if AITER_TRITON_CONFIGS_PATH is None:
+  AITER_TRITON_CONFIGS_PATH = os.path.join(os.path.dirname(__file__), "aiter_configs")
+
+
+# Standard bounds for M_LEQ_x keys (tuple for hashability with LRU cache)
+STANDARD_M_BOUNDS = (4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192)
+
+# This flag should be set to True, unless it is being used for debugging
+USE_LRU_CACHE = True
+
+
+def serialize_dict(d: dict) -> str:
+  return json.dumps(d)
+
+
+def deserialize_str(s: str) -> dict:
+  return json.loads(s)
+
+
+def _load_config_file(
+  cache_dict: dict,
+  cache_key: str,
+  fpath: str,
+  config_key: str,
+  fpath_should_exist: bool = False,
+) -> bool:
+  """
+  Helper function to load a config file and cache it.
+  """
+  if os.path.exists(fpath):
+    with open(fpath, "r") as file:
+      config = json.load(file)
+    cache_dict[cache_key][config_key] = config
+    return True
+  elif fpath_should_exist:
+    raise AssertionError(f"Required config file doesn't exist: {fpath}")
+  return False
+
+
+@functools.lru_cache(maxsize=1024 if USE_LRU_CACHE else 0)
+def get_gemm_config(
+  config_name: str,
+  M: int,
+  N: int | None = None,
+  K: int | None = None,
+  bounds: tuple[int, ...] | None = None,
+  specialized_filename: str | None = None,
+) -> tuple[dict, bool]:
+  """
+  Load a GEMM configuration using the standardized M_LEQ_x/M_GEQ_y/any format.
+
+  This function provides a unified way to load GEMM configs across all kernels.
+  It uses the following logic:
+  1. Load default config file: {arch}-{config_name}.json
+  2. If N and K are provided, try to load specialized config: {arch}-{config_name}-N={N}-K={K}.json
+     Or if specialized_filename is provided, use: {arch}-{config_name}-{specialized_filename}.json
+  3. Search for M_LEQ_x keys in order of bounds (default: STANDARD_M_BOUNDS)
+  4. If no M_LEQ_x matches, search for M_GEQ_x keys in reverse order
+  5. Fall back to "any" if no bounds match
+
+  Args:
+      config_name: Name of the config (example - "GEMM-A16W16")
+      M: M dimension of the GEMM
+      N: N dimension of the GEMM (optional)
+      K: K dimension of the GEMM (optional)
+      bounds: Custom bounds to use instead of STANDARD_M_BOUNDS (optional)
+      specialized_filename: Custom specialized filename suffix (optional)
+
+  Returns:
+      Dictionary with the config params,
+      bool indicating if the config is tuned.(True if tuned, False otherwise)
+  """
+  # Input validation
+  assert M >= 0, "M must be positive."
+  assert N is None or N > 0, "N must be positive when provided."
+  assert K is None or K > 0, "K must be positive when provided."
+  assert bounds is None or (
+    len(bounds) > 0
+    and all(x > 0 for x in bounds)
+    and all(x < y for x, y in zip(bounds, bounds[1:]))
+  ), (
+    "When provided, bounds must be a non-empty tuple of strictly increasing positive numbers."
+  )
+
+  if not hasattr(get_gemm_config, "_config_cache"):
+    get_gemm_config._config_cache = {}
+
+  dev = arch_info.get_arch()
+  cache_key = f"{dev}_{config_name}"
+
+  if cache_key not in get_gemm_config._config_cache:
+    get_gemm_config._config_cache[cache_key] = {}
+
+    # Load default config (must exist)
+    fpath = f"{AITER_TRITON_CONFIGS_PATH}/gemm/{dev}-{config_name}.json"
+    _load_config_file(
+      get_gemm_config._config_cache,
+      cache_key,
+      fpath,
+      "default",
+      fpath_should_exist=True,
+    )
+
+  config_dict_key = "default"
+
+  # Handle custom specialized filename (for fused kernels with multiple N dims)
+  if specialized_filename is not None:
+    spec_key = specialized_filename
+    if spec_key not in get_gemm_config._config_cache[cache_key]:
+      fpath = f"{AITER_TRITON_CONFIGS_PATH}/gemm/{dev}-{config_name}-{specialized_filename}.json"
+      if _load_config_file(get_gemm_config._config_cache, cache_key, fpath, spec_key):
+        config_dict_key = spec_key
+    else:
+      config_dict_key = spec_key
+
+  elif N is not None and K is not None:
+    nk_key = f"{N}_{K}"
+    if nk_key not in get_gemm_config._config_cache[cache_key]:
+      # load specialized config
+      fpath = f"{AITER_TRITON_CONFIGS_PATH}/gemm/{dev}-{config_name}-N={N}-K={K}.json"
+      if _load_config_file(get_gemm_config._config_cache, cache_key, fpath, nk_key):
+        config_dict_key = nk_key
+    else:
+      config_dict_key = nk_key
+
+  config_dict = get_gemm_config._config_cache[cache_key][config_dict_key]
+
+  # use standard bounds unless custom bounds are passed
+  search_bounds = bounds if bounds is not None else STANDARD_M_BOUNDS
+
+  # Search for M_LEQ_x keys
+  for bound in search_bounds:
+    key = f"M_LEQ_{bound}"
+    if M <= bound and key in config_dict:
+      return dict(config_dict[key]), config_dict_key != "default"
+
+  # Search for M_GEQ_x keys
+  for bound in reversed(search_bounds):
+    key = f"M_GEQ_{bound}"
+    if M >= bound and key in config_dict:
+      return dict(config_dict[key]), config_dict_key != "default"
+
+  if "any" in config_dict:
+    return dict(config_dict["any"]), False
+
+  raise KeyError(
+    f"No matching configuration found for M={M}, N={N}, K={K} in config '{config_name}'."
+  )
+
+
+#######################################################################################
+
+
+@triton.jit
+def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
+  ## pid remapping on xcds
+  # Number of pids per XCD in the new arrangement
+  pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+  # When GRID_MN cannot divide NUM_XCDS, some xcds will have
+  # pids_per_xcd pids, the other will have pids_per_xcd - 1 pids.
+  # We calculate the number of xcds that have pids_per_xcd pids as
+  # tall_xcds
+  tall_xcds = GRID_MN % NUM_XCDS
+  tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+  # Compute current XCD and local pid within the XCD
+  xcd = pid % NUM_XCDS
+  local_pid = pid // NUM_XCDS
+  # Calculate new pid based on the new grouping
+  # Note that we need to consider the following two cases:
+  # 1. the current pid is on a tall xcd
+  # 2. the current pid is on a short xcd
+  if xcd < tall_xcds:
+    pid = xcd * pids_per_xcd + local_pid
+  else:
+    pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+  return pid
+
+
+@triton.jit
+def pid_grid(pid: int, num_pid_m: int, num_pid_n: int, GROUP_SIZE_M: tl.constexpr = 1):
+  """
+  Maps 1D pid to 2D grid coords (pid_m, pid_n).
+
+  Args:
+      - pid: 1D pid
+      - num_pid_m: grid m size
+      - num_pid_n: grid n size
+      - GROUP_SIZE_M: tl.constexpr: default is 1
+  """
+  if GROUP_SIZE_M == 1:
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+  else:
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    tl.assume(group_size_m >= 0)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+  return pid_m, pid_n
+
+
+#######################################################################################
+
+# dtypes
+defaultDtypes = {
+  "gfx942": {"fp8": jnp.float8_e4m3fnuz},
+  "gfx950": {"fp8": jnp.float8_e4m3fn},
+  "gfx1250": {"fp8": jnp.float8_e4m3fn},
+}
+
+_8bit_fallback = jnp.uint8
+
+
+def get_dtype_fp8():
+  return defaultDtypes.get(arch_info.get_arch(), {"fp8": _8bit_fallback})["fp8"]
+
+
+i4x2 = getattr(jnp, "int4", _8bit_fallback)
+fp4x2 = getattr(jnp, "float4_e2m1fn_x2", _8bit_fallback)
+fp8 = get_dtype_fp8()
+fp8_e8m0 = getattr(jnp, "float8_e8m0fnu", _8bit_fallback)
+fp16 = jnp.float16
+bf16 = jnp.bfloat16
+fp32 = jnp.float32
+u32 = jnp.uint32
+i32 = jnp.int32
+i16 = jnp.int16
+i8 = jnp.int8
+
+d_dtypes = {
+  "fp8": fp8,
+  "fp8_e8m0": fp8_e8m0,
+  "fp16": fp16,
+  "bf16": bf16,
+  "fp32": fp32,
+  "i4x2": i4x2,
+  "fp4x2": fp4x2,
+  "u32": u32,
+  "i32": i32,
+  "i16": i16,
+  "i8": i8,
+}
+
+
+#######################################################################################
+
+
+@functools.lru_cache()
+def get_dtype_max(dtype):
+  if jnp.issubdtype(dtype, jnp.floating):
+    dtypeMax = jnp.finfo(dtype).max
+  elif jnp.issubdtype(dtype, jnp.integer):
+    dtypeMax = jnp.iinfo(dtype).max
+  else:
+    raise ValueError(f"Unsupported dtype: {dtype}")
+  return dtypeMax
+
+
+def pertoken_quant(
+  x,
+  scale=None,
+  x_scale=None,  # smooth_scale
+  scale_dtype=fp32,
+  quant_dtype=i8,
+  dtypeMax=None,
+):
+  x = x.astype(fp32)
+  if x_scale is None:
+    hidden_states = x
+  else:
+    # smooth quant
+    hidden_states = x * x_scale
+
+  if dtypeMax is None:
+    dtypeMax = get_dtype_max(quant_dtype)
+
+  per_token_scale = scale
+  if scale is None:
+    # [m, 1]
+    # per_token_amax, _ = torch.max(input=torch.abs(hidden_states), dim=-1, keepdim=True)
+    per_token_amax, _ = jnp.max(jnp.abs(hidden_states), axis=-1, keepdims=True)
+    per_token_scale = per_token_amax / dtypeMax
+    per_token_scale[per_token_scale == 0] = 1
+
+  # quant hidden_states
+  y = (hidden_states / per_token_scale).astype(quant_dtype)
+  y_scale = per_token_scale.astype(scale_dtype)
+  return y, y_scale
+
+def per_tensor_quant(
+    x, scale=None, scale_dtype=fp32, quant_dtype=i8, dtypeMax=None
+):
+    x = x.astype(fp32)
+    if scale is None:
+        if dtypeMax is None:
+            dtypeMax = get_dtype_max(quant_dtype)
+        scale = jnp.abs(x).max() / dtypeMax
+    y = x / scale
+
+    scale = jnp.reshape(scale,(-1,))
+    assert scale.size == 1
+
+    return y.astype(quant_dtype), scale.astype(scale_dtype)

--- a/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4-N=128-K=512.json
+++ b/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4-N=128-K=512.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4-N=512-K=128.json
+++ b/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4-N=512-K=128.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4.json
+++ b/AMD/aiter_configs/gemm/gfx950-BATCHED_GEMM-AFP4WFP4.json
@@ -1,0 +1,80 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "kpack": 1,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16-N4=512-N16=256-K=7168.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 14
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 7
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 7
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16.json
+++ b/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4-A16W16.json
@@ -1,0 +1,14 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4_PRESHUFFLED-A16W16.json
+++ b/AMD/aiter_configs/gemm/gfx950-FUSED-GEMM-AFP4WFP4_PRESHUFFLED-A16W16.json
@@ -1,0 +1,38 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4 copy.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4 copy.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 16
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=106496-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=106496-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=1280-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=1280-K=8192.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 16
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=13312-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=13312-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=13312.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=13312.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=2048.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=2048.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=26624.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=26624.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=4096.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=4096.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=53248.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=53248.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=6656.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=6656.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=16384-K=8192.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=18432-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=18432-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=2112-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=2112-K=7168.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 14
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 14
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=2304-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=2304-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 2,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=26624-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=26624-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=3072-K=1536.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=3072-K=1536.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=4608-K=7168.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=512-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=512-K=7168.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=53248-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=53248-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 2
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2048.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2048.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2304.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=2304.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=256.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=7168-K=256.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=9216-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4-N=9216-K=16384.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4.json
@@ -1,0 +1,74 @@
+{
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 16
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 3,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=10240-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=10240-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=106496-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=106496-K=16384.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=1280-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=1280-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=14336-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=14336-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=16384-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=16384-K=16384.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=16384-K=53248.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=16384-K=53248.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=18432-K=16384.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=18432-K=16384.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=2112-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=2112-K=7168.json
@@ -1,0 +1,86 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 4,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 14
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 14
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 7
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 1024,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 1024,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=2560-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=2560-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=28672-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=28672-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=3072-K=1536.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=3072-K=1536.json
@@ -1,0 +1,86 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 8,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=4096-K=512.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=4096-K=512.json
@@ -1,0 +1,86 @@
+{
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_16": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "any": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 512,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 1,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=5120-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=5120-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=57344-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=57344-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=7168-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=7168-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=1024.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=1024.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 6,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=14336.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=14336.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=2048.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=2048.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=28672.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=28672.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 7
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=3584.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=3584.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=4096.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=4096.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 16,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=7168.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=7168.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 8
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=8192.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=8192.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 1024,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 4
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+        "waves_per_eu": 4,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 512,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg",
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED.json
+++ b/AMD/aiter_configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED.json
@@ -1,0 +1,86 @@
+{
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "M_LEQ_256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    },
+    "any": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 4,
+        "num_warps": 2,
+        "num_stages": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/aiter_configs/gemm/gluon/gfx950-GEMM-AFP4WFP4.json
+++ b/AMD/aiter_configs/gemm/gluon/gfx950-GEMM-AFP4WFP4.json
@@ -1,0 +1,14 @@
+{
+    "any": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 2,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 32,
+        "cache_modifier": null,
+        "NUM_KSPLIT": 1
+    }
+}

--- a/AMD/arch_info.py
+++ b/AMD/arch_info.py
@@ -1,0 +1,28 @@
+import triton
+from functools import lru_cache
+import jax
+import ctypes
+
+
+# https://github.com/ROCm/aiter/blob/7411c99753f0661a3eecdbdb1b36feb58539f62b/aiter/ops/triton/utils/_triton/arch_info.py
+@lru_cache(maxsize=1)
+def get_arch() -> str:
+  try:
+    arch = (
+      triton.runtime.driver.active.get_current_target().arch
+    )  # If running with torch
+  except RuntimeError:  # else running with JAX
+    from jax._src.lib import gpu_triton as triton_kernel_call_lib
+
+    arch = triton_kernel_call_lib.get_arch_details("0")
+    arch = arch.split(":")[0]
+
+  return arch
+
+
+def is_fp4_avail():
+  return get_arch() in ("gfx950")
+
+
+def is_fp8_avail():
+  return get_arch() in ("gfx942", "gfx950")

--- a/AMD/benchmarks.py
+++ b/AMD/benchmarks.py
@@ -1,0 +1,405 @@
+import argparse
+from functools import partial
+from collections.abc import Callable
+import itertools
+import os
+import time
+
+try:
+  import benchstats
+except ImportError:
+  print("ERROR: Please run 'pip install benchstats' to install benchstats package required for benchmarks.")
+  exit(1)
+
+from benchstats import qbench as qb
+from benchstats.common import LoggingConsole
+from benchstats.render import makeReadable
+import jax
+import jax.numpy as jnp
+import jax_triton as jt
+import numpy as np
+import triton
+import triton.language as tl
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import arch_info
+
+
+######################################################################  gemm_afp4wfp4
+
+
+@qb.registerBenchmark
+def make_gemm_afp4wfp4_benchmark() -> dict[str, tuple[Callable, Callable]]:
+  if not arch_info.is_fp4_avail():
+    print(
+      "MXFP4 not supported on this architecture (requires CDNA4). Skipping gemm_afp4wfp4 benchmarks."
+    )
+    return {}
+
+  from gemm_afp4wfp4_test import generate_gemm_afp4wfp4_inputs
+  from gemm_afp4wfp4_gluon import gemm_afp4wfp4 as gluon_gemm_afp4wfp4
+  from gemm_afp4wfp4_triton import gemm_afp4wfp4 as triton_gemm_afp4wfp4
+
+  k = jax.random.key(42)
+
+  def init(M, N, K, dtype, layout="TN", output=True, skip_reduce=False) -> list:
+    nonlocal k
+    if _random_inputs:
+      k, s = jax.random.split(k)
+    else:
+      s = k
+    (x, _, w_triton, _, _, x_scales_triton, w_scales_triton) = (
+      generate_gemm_afp4wfp4_inputs(M, N, K, dtype, layout=layout, output=output, key=s)
+    )
+    return [x, w_triton, x_scales_triton, w_scales_triton, dtype, None, skip_reduce]
+
+  def instantiate_config(m_n_k, dtype, layout, output, skip_reduce, is_gluon):
+    return lambda: init(
+      *m_n_k, dtype, layout=layout, output=output, skip_reduce=skip_reduce
+    )
+
+  def make_benchmarks(cfg):
+    return {
+      f"gemm_afp4wfp4({m_n_k[0]},{m_n_k[1]},{m_n_k[2]},{dtype.__name__},{layout},"
+      f"{'output' if output else 'no_output'},{'skip' if skip_reduce else 'no_skip'})|{'gluon' if is_gluon else 'triton'}": (
+        gluon_gemm_afp4wfp4 if is_gluon else triton_gemm_afp4wfp4,
+        instantiate_config(m_n_k, dtype, layout, output, skip_reduce, is_gluon),
+      )
+      for m_n_k, dtype, layout, output, skip_reduce, is_gluon in cfg
+    }
+
+  # gluon kernel config is optimized for M=N=K=8192, so to compare apples to apples,
+  # trying values around that
+  drop_similar = True  # don't benchmark configs yielding not much different results
+
+  ret = make_benchmarks(
+    itertools.product(
+      [
+        (8192, 8192, 8192),
+      ],
+      [jnp.bfloat16] if drop_similar else [jnp.bfloat16, jnp.float16],
+      ["TN"] if drop_similar else ["TN", "TT", "NN", "NT"],
+      [False] if drop_similar else [True, False],
+      [False] if drop_similar else [True, False],
+      [False, True],  # is_gluon
+    )
+  )
+  if not _single_gemm:
+    ret.update(
+      make_benchmarks(
+        itertools.product(
+          [
+            (4 * 8192, 4 * 8192, 4 * 8192),
+            (8192 // 2, 8192 // 2, 8192 // 2),
+            (8192 // 4, 8192 // 4, 8192 // 4),
+            (4 * 8192, 8192, 4 * 8192),
+            (8192, 4 * 8192, 8192),
+            (8192 // 2, 8192 * 2, 8192 // 2),
+            (8192 // 4, 8192 * 4, 8192 // 4),
+            (8192 * 4, 8192 // 4, 8192 * 4),
+            (4864, 8192, 4160),
+            (16, 16384, 3328 * 2),
+            # (128, 16384, 3328 * 2),
+            (256, 256, 256),
+            (256, 8192, 256),
+            (1, 1, 32),
+          ],
+          [jnp.bfloat16],  # [jnp.bfloat16, jnp.float16],
+          ["TN"],  # ["TN", "TT", "NN", "NT"],
+          [False],  # [True, False],
+          [False],  # [True, False],
+          [False, True],  # is_gluon
+        )
+      )
+    )
+  return ret
+
+
+######################################################################  startup
+
+
+@qb.registerBenchmark
+def make_startup_benchmark() -> dict[str, tuple[Callable, Callable]]:
+  """
+  Prepares benchmarking startup costs of triton vs gluon kernels.
+
+  Returns a dictionary of functions func_name->(init_func, bm_func), where bm_func takes
+  a list of arguments created by init_func and returns the operation result. The runner
+  takes care of doing jax.block_until_ready() on the input arguments and the result for
+  benchmarking. Runtime of bm_func is measured.
+
+  Types of benchmark we want to see:
+  non-jitted:
+  - startup costs - how much does it cost to just launch a trivial kernel?
+      - not much, dozens microseconds
+  - does cost change if we supply large arrays?
+      - there's an additional cost of transferring the array to the GPU memory, but the
+        cost of invocation is about the same.
+
+  jitted:
+  - does jitting the launcher changes the startup costs?
+    - makes the invocation a few dozen percents faster.
+  - does the cost of jitted launch change if we supply large arrays?
+    - gets about the same speedup as for a scalar argument, which is basically hidden by
+      the cost of transferring arrays to/from the GPU memory.
+    - most important caveat: using an input-output argument without donating it to the
+        launcher has an additional cost of copying that argument before
+        passing it to the kernel (JAX arrays are immutable by default). This *might* not
+        happen if the in-out argument is never used later (or specifically assigned to
+        the result of the kernel invocation? - this wasn't tested) AND the whole
+        launcher invocation is jitted so a compiler could see that the argument is never
+        used later, but this might be a fragile assumption. Beware.
+
+  jitted with donation:
+  - does the cost of jitted launch change if we supply args with donation?
+    - removes the additional cost of copying the argument before passing it to the
+      kernel.
+  """
+  NGigs = 4
+
+  @triton.jit
+  def copy_scalar_triton(in_ptr, out_ptr):
+    value = tl.load(in_ptr)
+    tl.store(out_ptr, value)
+
+  @gluon.jit
+  def copy_scalar_gluon(in_ptr, out_ptr):
+    value = gl.load(in_ptr)
+    gl.store(out_ptr, value)
+
+  def startup(input: jnp.ndarray, kernel) -> jnp.ndarray:
+    return jt.triton_call(
+      input,
+      kernel=kernel,
+      out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
+      grid=1,
+    )
+
+  # beware - that launcher better be called with jitting and donation of the output
+  def startup_out(input: jnp.ndarray, output: jnp.ndarray, kernel) -> jnp.ndarray:
+    return jt.triton_call(
+      input,
+      output,
+      kernel=kernel,
+      out_shape=jax.ShapeDtypeStruct(shape=input.shape, dtype=input.dtype),
+      grid=1,
+      input_output_aliases={1: 0},
+    )
+
+  def init_scalar() -> list:
+    return [jnp.array(42.314)]
+
+  def init_vec() -> list:
+    return [jnp.arange(NGigs * 1024 * 1024 * 1024)]
+
+  def init_vec_out() -> list:
+    i = jnp.arange(NGigs * 1024 * 1024 * 1024)
+    return [i, jnp.empty_like(i)]
+
+  # fmt: off
+  return {
+    "startup(1)|triton": (lambda x: startup(x, copy_scalar_triton), init_scalar),
+    "startup(1)|gluon": (lambda x: startup(x, copy_scalar_gluon), init_scalar),
+    "startup(1) jcall|triton": (jax.jit(lambda x: startup(x, copy_scalar_triton)), init_scalar),
+    "startup(1) jcall|gluon": (jax.jit(lambda x: startup(x, copy_scalar_gluon)), init_scalar),
+    #
+    # f"startup({NGigs}G)|triton": (lambda x: startup(x, copy_scalar_triton), init_scalar),      # about the same as
+    # f"startup({NGigs}G)|gluon": (lambda x: startup(x, copy_scalar_gluon), init_scalar),        # `out jcall` below
+    f"startup({NGigs}G) jcall|triton": (jax.jit(lambda x: startup(x, copy_scalar_triton)), init_vec),
+    f"startup({NGigs}G) jcall|gluon": (jax.jit(lambda x: startup(x, copy_scalar_gluon)), init_vec),
+    # jitted with output
+    # f"startup({NGigs}G) out|triton": (lambda x, y: startup_out(x, y, copy_scalar_triton), init_vec_out),  # about the same as
+    # f"startup({NGigs}G) out|gluon": (lambda x, y: startup_out(x, y, copy_scalar_gluon), init_vec_out),    # `out jcall` below
+    f"startup({NGigs}G) out jcall|triton": (jax.jit(lambda x, y: startup_out(x, y, copy_scalar_triton)), init_vec_out),
+    f"startup({NGigs}G) out jcall|gluon": (jax.jit(lambda x, y: startup_out(x, y, copy_scalar_gluon)), init_vec_out),
+    # jitted with output donation
+    f"startup({NGigs}G) donate jcall|triton": (jax.jit(lambda x, y: startup_out(x, y, copy_scalar_triton), donate_argnums=(1,)), init_vec_out),
+    f"startup({NGigs}G) donate jcall|gluon": (jax.jit(lambda x, y: startup_out(x, y, copy_scalar_gluon), donate_argnums=(1,)), init_vec_out),
+  }
+  # fmt: on
+
+
+######################################################################  runner stuff
+
+
+class CacheFlusher:
+  def __init__(self, _cache_size_bytes=256 * 1024 * 1024):
+    _clearers = {}
+    for d in jax.devices():
+      _clearers[d] = jnp.arange(_cache_size_bytes // 4, dtype=jnp.uint32, device=d)
+    self._clearers = _clearers
+
+    # impl in Triton just zeroes a tensor. Read-write might be a bit more reliable
+    @triton.jit
+    def _inc_kernel(output_ptr, N: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+      pid = tl.program_id(0)
+      offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+      mask = offsets < N
+      values = tl.load(output_ptr + offsets, mask=mask)
+      tl.store(output_ptr + offsets, values + 1, mask=mask)
+
+    @partial(jax.jit, donate_argnums=(0,))
+    def _reset_array(arr: jnp.ndarray):
+      assert arr.dtype == jnp.uint32
+      N = arr.size
+      BLOCK_SIZE = 1024
+      grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE,)
+      return jt.triton_call(
+        arr,
+        kernel=_inc_kernel,
+        out_shape=arr,
+        grid=grid,
+        input_output_aliases={0: 0},
+        N=N,
+        BLOCK_SIZE=BLOCK_SIZE,
+      )
+
+    self._reset_array = _reset_array
+
+  def flush(self, inputs):
+    device_set = set()
+    objs = []
+    for inp in inputs:
+      if isinstance(inp, jnp.ndarray) and inp.device not in device_set:
+        device_set.add(inp.device)
+        cl = self._clearers[inp.device]
+        o = self._reset_array(cl)
+        del cl
+        self._clearers[inp.device] = o
+        objs.append(o)
+    for o in objs:
+      jax.block_until_ready(o)
+
+
+def run_benchmarks(args: argparse.Namespace):
+  global _single_gemm, _random_inputs
+  _single_gemm = args.single_gemm
+  _random_inputs = args.random_inputs
+
+  start = time.perf_counter_ns()
+
+  benchmark_sets = args.benchmark_sets or qb.getRegisteredBenchmarkSetNames()
+
+  if args.clear_cache:
+    print("Will flush L2 cache before each run")
+    cache_flusher = CacheFlusher()
+
+    def clear_l2(inputs):
+      cache_flusher.flush(inputs)
+
+  else:
+    print("L2 cache WON'T be flushed!")
+
+    def clear_l2(inputs):
+      pass
+
+  if args.export_path_pfx:
+    enabled_str = "-".join(benchmark_sets)
+    fname_base = (
+      f"{args.export_path_pfx}_{enabled_str}"
+      f"_i{args.iters}_r{args.reps}"
+      + ("_SG" if args.single_gemm else "")
+      + ("" if args.random_inputs else "_NrI")
+      + ("" if args.randomize_iterations else "_NrIT")
+      + ("" if args.clear_cache else "_NCC")
+      + ("_BF" if args.batch_functions else "")
+      + "_"
+    )
+    c = 0
+    while True:
+      f = f"{fname_base}{c}.svg"
+      if os.path.exists(f):
+        c += 1
+      else:
+        fname_base = f
+        break
+
+    console = LoggingConsole(record=True)
+  else:
+    fname_base = None
+    console = LoggingConsole()
+
+  bms = qb.getRegisteredBenchmarks(benchmark_sets)
+  assert len(bms) > 0, "No benchmark sets were enabled, shouildn't be here"
+
+  bm_names = tuple(bms.keys())
+  all_bms = '", "'.join(bm_names)
+  print(
+    f'Going to run {len(bm_names)} benchmarks ({jax.local_device_count()} device(s) available): "{all_bms}"'
+  )
+  if jax.local_device_count() > 1:
+    console.warning(
+      "More than 1 device is visible. For potentially better results consistency, restrict the number of devices using ROCR_VISIBLE_DEVICES or similar environment variable."
+    )
+
+  # we're interested in a wall-clock time of invoking kernels, including all python
+  # related overhead, so time.perf_counter_ns() used there is appropriate
+  _, results = qb.benchmark(
+    bms.values(),
+    iters=args.iters,
+    reps=args.reps,
+    warmup=args.warmup,
+    randomize_iterations=args.randomize_iterations,
+    batch_functions=args.batch_functions,
+    wait_complete=jax.block_until_ready,
+    clear_cache=clear_l2,
+    show_progress_each=1 if args.batch_functions else 10,
+    bm_names=bm_names,
+    alt_delimiter="|",
+    metrics={"mean": np.mean, "median": np.median, "min": np.min},
+    console=console,
+    pvalue_stats_bootstrap=args.pvalue_stats_bootstrap,
+  )
+
+  end = time.perf_counter_ns()
+  console.print(f"Done in {makeReadable((end - start) * 1e-9, 1)}s")
+
+  if fname_base is not None:
+    console.save_svg(fname_base, title=_g_ProgramName, clear=False)
+
+    fname_base = f"{fname_base[:-4]}.txt"
+    console.save_text(fname_base)
+
+    fname_base = f"{fname_base[:-4]}.npy"
+    np.save(fname_base, results)
+
+    print(f"Saved results to {fname_base[:-4]}")
+
+  return results
+
+
+_g_ProgramName = "Triton/Gluon benchmarks runner"
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description=_g_ProgramName,
+  )
+  parser = qb.makeArgumentParser(parser)
+
+  parser.add_argument(
+    "--single_gemm",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help="Only benchmark the base gemm size (default: False)",
+  )
+  parser.add_argument(
+    "--random_inputs",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Use random input data vs deterministic arange (default: True)",
+  )
+  parser.add_argument(
+    "--clear_cache",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Clear L2 cache before each run (default: True)",
+  )
+
+  args = parser.parse_args()
+  run_benchmarks(args)
+
+
+if __name__ == "__main__":
+  main()

--- a/AMD/gemm_afp4wfp4_gluon.py
+++ b/AMD/gemm_afp4wfp4_gluon.py
@@ -1,0 +1,735 @@
+# based on https://github.com/ROCm/aiter/blob/7411c99753f0661a3eecdbdb1b36feb58539f62b/aiter/ops/triton/gluon/gemm_afp4wfp4.py
+# Kernels were copypasted and output pointer was moved to the last position.
+# The launch function was rewritten to use JAX primitives and match jax-triton calling
+# conventions
+
+import functools
+import json
+from typing import Optional, Tuple
+
+from strided_array import StridedArray
+
+import jax
+import jax.numpy as jnp
+import jax_triton as jt
+import triton
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import _aiter
+import arch_info
+
+global _USE_GEMM_SPLITK_BF16
+_USE_GEMM_SPLITK_BF16 = False
+
+
+@triton.heuristics({
+  "EVEN_K": lambda args: (
+    (args["K"] % (args["BLOCK_SIZE_K"] // 2) == 0)
+    and (args["SPLITK_BLOCK_SIZE"] % args["BLOCK_SIZE_K"] == 0)
+    and (args["K"] % (args["SPLITK_BLOCK_SIZE"] // 2) == 0)
+  ),
+})
+@gluon.jit
+def _gemm_afp4wfp4_kernel(
+  a_ptr,
+  b_ptr,
+  # c_ptr,
+  a_scales_ptr,
+  b_scales_ptr,
+  M,
+  N,
+  K,
+  stride_am,
+  stride_ak,
+  stride_bk,
+  stride_bn,
+  stride_ck,
+  stride_cm,
+  stride_cn,
+  stride_asm,
+  stride_ask,
+  stride_bsn,
+  stride_bsk,
+  c_ptr,  # output goes last
+  # Meta-parameters
+  BLOCK_SIZE_M: gl.constexpr,
+  BLOCK_SIZE_N: gl.constexpr,
+  BLOCK_SIZE_K: gl.constexpr,
+  GROUP_SIZE_M: gl.constexpr,
+  NUM_KSPLIT: gl.constexpr,
+  SPLITK_BLOCK_SIZE: gl.constexpr,
+  EVEN_K: gl.constexpr,
+  num_warps: gl.constexpr,
+  num_stages: gl.constexpr,
+  waves_per_eu: gl.constexpr,
+  matrix_instr_nonkdim: gl.constexpr,
+  cache_modifier: gl.constexpr,
+):
+  """
+  Kernel for computing the matmul C = A x B.
+  A and B inputs are in the microscale fp4 (mxfp4) format.
+  A_scales and B_scales are in e8m0 format.
+  A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+  """
+  GRID_MN = gl.cdiv(M, BLOCK_SIZE_M) * gl.cdiv(N, BLOCK_SIZE_N)
+
+  # -----------------------------------------------------------
+  # Map program ids `pid` to the block of C it should compute.
+  # This is done in a grouped ordering to promote L2 data reuse.
+  pid_unified = gl.program_id(axis=0)
+  # remap so that XCDs get continous chunks of pids (of CHUNK_SIZE).
+  pid_unified = _aiter.remap_xcd(pid_unified, GRID_MN * NUM_KSPLIT, NUM_XCDS=8)
+
+  pid_k = pid_unified % NUM_KSPLIT
+  pid = pid_unified // NUM_KSPLIT
+  num_pid_m = gl.cdiv(M, BLOCK_SIZE_M)
+  num_pid_n = gl.cdiv(N, BLOCK_SIZE_N)
+
+  if NUM_KSPLIT == 1:
+    pid_m, pid_n = _aiter.pid_grid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M=GROUP_SIZE_M)
+  else:
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+  # We assume 32 elements along K share the same scale.
+  SCALE_GROUP_SIZE: gl.constexpr = 32
+
+  blocked_mk: gl.constexpr = gl.BlockedLayout(
+    size_per_thread=[1, 16],
+    threads_per_warp=[8, 8],
+    warps_per_cta=[num_warps, 1],
+    order=[1, 0],
+  )
+
+  blocked_kn: gl.constexpr = gl.BlockedLayout(
+    size_per_thread=[16, 1],
+    threads_per_warp=[8, 8],
+    warps_per_cta=[1, num_warps],
+    order=[0, 1],
+  )
+
+  blocked_scales: gl.constexpr = gl.BlockedLayout(
+    size_per_thread=[4, 1],
+    threads_per_warp=[64, 1],
+    warps_per_cta=[1, num_warps],
+    order=[0, 1],
+  )
+
+  linear_as: gl.constexpr = gl.DistributedLinearLayout(
+    reg_bases=[[0, 2], [0, 4], [64, 0], [128, 0]],
+    lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]],
+    warp_bases=[[0, 0], [0, 0], [32, 0]],
+    block_bases=[],
+    shape=[BLOCK_SIZE_M, BLOCK_SIZE_K // SCALE_GROUP_SIZE],
+  )
+
+  linear_bs: gl.constexpr = gl.DistributedLinearLayout(
+    reg_bases=[[0, 2], [0, 4], [128, 0]],
+    lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 1]],
+    warp_bases=[[32, 0], [64, 0], [0, 0]],
+    block_bases=[],
+    shape=[BLOCK_SIZE_N, BLOCK_SIZE_K // SCALE_GROUP_SIZE],
+  )
+
+  linear_mn: gl.constexpr = gl.DistributedLinearLayout(
+    reg_bases=[[0, 1], [0, 2], [0, 4], [0, 16], [0, 128], [64, 0], [128, 0]],
+    lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 8]],
+    warp_bases=[[0, 32], [0, 64], [32, 0]],
+    block_bases=[],
+    shape=[BLOCK_SIZE_M, BLOCK_SIZE_N],
+  )
+
+  shared_a: gl.constexpr = gl.SwizzledSharedLayout(
+    vec=16, per_phase=2, max_phase=8, order=[1, 0]
+  )
+
+  shared_b: gl.constexpr = gl.SwizzledSharedLayout(
+    vec=16, per_phase=2, max_phase=8, order=[0, 1]
+  )
+
+  shared_scales: gl.constexpr = gl.SwizzledSharedLayout(
+    vec=1, per_phase=1, max_phase=1, order=[0, 1]
+  )
+
+  mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+    version=4,
+    instr_shape=[32, 32, 64],
+    transposed=True,
+    warps_per_cta=[2, num_warps // 2],
+  )
+
+  dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+    operand_index=0, parent=mfma_layout, k_width=16
+  )
+  dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+    operand_index=1, parent=mfma_layout, k_width=16
+  )
+
+  if (pid_k * SPLITK_BLOCK_SIZE // 2) < K:
+    num_k_iter = gl.cdiv(SPLITK_BLOCK_SIZE // 2, BLOCK_SIZE_K // 2)
+
+    # Create pointers for first block of A and B input matrices
+    # The BLOCK sizes are of the elements and in fp4 we pack 2 per uint8 container.
+    offs_ak = gl.arange(0, BLOCK_SIZE_K // 2, layout=gl.SliceLayout(0, blocked_mk))
+    offs_ak_split = pid_k * (SPLITK_BLOCK_SIZE // 2) + offs_ak
+    offs_bk = gl.arange(0, BLOCK_SIZE_K // 2, layout=gl.SliceLayout(1, blocked_kn))
+    offs_bk_split = pid_k * (SPLITK_BLOCK_SIZE // 2) + offs_bk
+    offs_am = (
+      pid_m * BLOCK_SIZE_M
+      + gl.arange(0, BLOCK_SIZE_M, layout=gl.SliceLayout(1, blocked_mk))
+    ) % M
+    offs_bn = (
+      pid_n * BLOCK_SIZE_N
+      + gl.arange(0, BLOCK_SIZE_N, layout=gl.SliceLayout(0, blocked_kn))
+    ) % N
+    offs_a = offs_am[:, None] * stride_am + offs_ak_split[None, :] * stride_ak
+    offs_b = offs_bk_split[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+
+    # Create pointers for the first block of A and B scales
+    offs_ks = gl.arange(
+      0,
+      BLOCK_SIZE_K // SCALE_GROUP_SIZE,
+      layout=gl.SliceLayout(0, blocked_scales),
+    )
+    offs_ks_split = (pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE)) + offs_ks
+    offs_asm = (
+      pid_m * BLOCK_SIZE_M
+      + gl.arange(0, BLOCK_SIZE_M, layout=gl.SliceLayout(1, blocked_scales))
+    ) % M
+    offs_bsn = (
+      pid_n * BLOCK_SIZE_N
+      + gl.arange(0, BLOCK_SIZE_N, layout=gl.SliceLayout(1, blocked_scales))
+    ) % N
+
+    offs_as = offs_asm[:, None] * stride_asm + offs_ks_split[None, :] * stride_ask
+    # B scales are N x K even though B operand is K x N.
+    offs_bs = offs_bsn[:, None] * stride_bsn + offs_ks_split[None, :] * stride_bsk
+
+    # Create shared memories
+    smem_a = gl.allocate_shared_memory(
+      a_ptr.type.element_ty, [BLOCK_SIZE_M, BLOCK_SIZE_K // 2], layout=shared_a
+    )
+    smem_b = gl.allocate_shared_memory(
+      b_ptr.type.element_ty, [BLOCK_SIZE_K // 2, BLOCK_SIZE_N], layout=shared_b
+    )
+
+    smem_as = gl.allocate_shared_memory(
+      a_scales_ptr.type.element_ty,
+      [BLOCK_SIZE_M, BLOCK_SIZE_K // SCALE_GROUP_SIZE],
+      layout=shared_scales,
+    )
+    smem_bs = gl.allocate_shared_memory(
+      b_scales_ptr.type.element_ty,
+      [BLOCK_SIZE_N, BLOCK_SIZE_K // SCALE_GROUP_SIZE],
+      layout=shared_scales,
+    )
+
+    if EVEN_K:
+      a = gl.amd.cdna4.buffer_load(
+        ptr=a_ptr,
+        offsets=offs_a,
+      )
+      a_scales = gl.amd.cdna4.buffer_load(
+        ptr=a_scales_ptr,
+        offsets=offs_as,
+      )
+    else:
+      a = gl.amd.cdna4.buffer_load(
+        ptr=a_ptr,
+        offsets=offs_a,
+        mask=offs_ak[None, :] < K - pid_k * SPLITK_BLOCK_SIZE // 2,
+      )
+      a_scales = gl.amd.cdna4.buffer_load(
+        ptr=a_scales_ptr,
+        offsets=offs_as,
+        mask=offs_ks[None, :]
+        < (2 * K // SCALE_GROUP_SIZE) - pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE),
+      )
+
+    if EVEN_K:
+      b = gl.amd.cdna4.buffer_load(
+        ptr=b_ptr,
+        offsets=offs_b,
+        cache=cache_modifier,
+      )
+      b_scales = gl.amd.cdna4.buffer_load(
+        ptr=b_scales_ptr, offsets=offs_bs, cache=cache_modifier
+      )
+    else:
+      b = gl.amd.cdna4.buffer_load(
+        ptr=b_ptr,
+        offsets=offs_b,
+        mask=offs_bk[:, None] < K - pid_k * SPLITK_BLOCK_SIZE // 2,
+        cache=cache_modifier,
+      )
+      b_scales = gl.amd.cdna4.buffer_load(
+        ptr=b_scales_ptr,
+        offsets=offs_bs,
+        mask=offs_ks[None, :]
+        < (2 * K // SCALE_GROUP_SIZE) - pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE),
+        cache=cache_modifier,
+      )
+
+    smem_as.store(a_scales)
+    smem_a.store(a)
+
+    accumulator = gl.zeros(
+      (BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=gl.float32, layout=mfma_layout
+    )
+
+    # num_stages:2
+    for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter - 1):
+      # advance pointers
+      a_ptr += (BLOCK_SIZE_K // 2) * stride_ak
+      b_ptr += (BLOCK_SIZE_K // 2) * stride_bk
+      a_scales_ptr += (BLOCK_SIZE_K // SCALE_GROUP_SIZE) * stride_ask
+      b_scales_ptr += (BLOCK_SIZE_K // SCALE_GROUP_SIZE) * stride_bsk
+
+      if EVEN_K:
+        a = gl.amd.cdna4.buffer_load(
+          ptr=a_ptr,
+          offsets=offs_a,
+        )
+      else:
+        a = gl.amd.cdna4.buffer_load(
+          ptr=a_ptr,
+          offsets=offs_a,
+          mask=offs_ak[None, :] < K - (k + 1) * (BLOCK_SIZE_K // 2),
+        )
+      smem_b.store(b)
+      smem_bs.store(b_scales)
+      curr_a = smem_a.load(layout=dot_a_layout)
+      curr_a_scales = smem_as.load(layout=linear_as)
+
+      if EVEN_K:
+        a_scales = gl.amd.cdna4.buffer_load(
+          ptr=a_scales_ptr,
+          offsets=offs_as,
+        )
+      else:
+        a_scales = gl.amd.cdna4.buffer_load(
+          ptr=a_scales_ptr,
+          offsets=offs_as,
+          mask=offs_ks[None, :]
+          < (2 * K // SCALE_GROUP_SIZE) - (k + 1) * (BLOCK_SIZE_K // SCALE_GROUP_SIZE),
+        )
+
+      curr_b_scales = smem_bs.load(layout=linear_bs)
+      if EVEN_K:
+        b = gl.amd.cdna4.buffer_load(
+          ptr=b_ptr,
+          offsets=offs_b,
+          cache=cache_modifier,
+        )
+        b_scales = gl.amd.cdna4.buffer_load(
+          ptr=b_scales_ptr, offsets=offs_bs, cache=cache_modifier
+        )
+      else:
+        b = gl.amd.cdna4.buffer_load(
+          ptr=b_ptr,
+          offsets=offs_b,
+          mask=offs_bk[:, None] < K - (k + 1) * (BLOCK_SIZE_K // 2),
+          cache=cache_modifier,
+        )
+        b_scales = gl.amd.cdna4.buffer_load(
+          ptr=b_scales_ptr,
+          offsets=offs_bs,
+          mask=offs_ks[None, :]
+          < (2 * K // SCALE_GROUP_SIZE) - (k + 1) * (BLOCK_SIZE_K // SCALE_GROUP_SIZE),
+          cache=cache_modifier,
+        )
+      curr_b = smem_b.load(layout=dot_b_layout)
+
+      accumulator = gl.amd.cdna4.mfma_scaled(
+        a=curr_a,
+        a_scale=curr_a_scales,
+        a_format="e2m1",
+        b=curr_b,
+        b_scale=curr_b_scales,
+        b_format="e2m1",
+        acc=accumulator,
+      )
+
+      smem_a.store(a)
+      smem_as.store(a_scales)
+
+    # ======= Epilogue ========
+    smem_b.store(b)
+    smem_bs.store(b_scales)
+    curr_a = smem_a.load(layout=dot_a_layout)
+    curr_b = smem_b.load(layout=dot_b_layout)
+    curr_a_scales = smem_as.load(layout=linear_as)
+    curr_b_scales = smem_bs.load(layout=linear_bs)
+
+    accumulator = gl.amd.cdna4.mfma_scaled(
+      a=curr_a,
+      a_scale=curr_a_scales,
+      a_format="e2m1",
+      b=curr_b,
+      b_scale=curr_b_scales,
+      b_format="e2m1",
+      acc=accumulator,
+    )
+
+    c = accumulator.to(c_ptr.type.element_ty)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + gl.arange(
+      0, BLOCK_SIZE_M, layout=gl.SliceLayout(1, linear_mn)
+    )
+    offs_cn = pid_n * BLOCK_SIZE_N + gl.arange(
+      0, BLOCK_SIZE_N, layout=gl.SliceLayout(0, linear_mn)
+    )
+    offs_c = (
+      stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :] + pid_k * stride_ck
+    )
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+
+    c = gl.convert_layout(c, layout=linear_mn, assert_trivial=False)
+    gl.amd.cdna4.buffer_store(c, c_ptr, offs_c, c_mask)
+
+
+@gluon.jit
+def _gemm_afp4wfp4_reduce_kernel(
+  c_in_ptr,
+  # c_out_ptr,
+  M,
+  N,
+  stride_c_in_k,
+  stride_c_in_m,
+  stride_c_in_n,
+  stride_c_out_m,
+  stride_c_out_n,
+  c_out_ptr,  # output goes last
+  BLOCK_SIZE_M: gl.constexpr,
+  BLOCK_SIZE_N: gl.constexpr,
+  ACTUAL_KSPLIT: gl.constexpr,
+  MAX_KSPLIT: gl.constexpr,
+):
+
+  pid_m = gl.program_id(axis=0)
+  pid_n = gl.program_id(axis=1)
+
+  blocked_kmn: gl.constexpr = gl.BlockedLayout(
+    size_per_thread=[1, 1, 4],
+    threads_per_warp=[2, 2, 16],
+    warps_per_cta=[1, 4, 1],
+    order=[2, 0, 1],
+  )
+
+  blocked_mn: gl.constexpr = gl.BlockedLayout(
+    size_per_thread=[1, 4],
+    threads_per_warp=[4, 16],
+    warps_per_cta=[4, 1],
+    order=[1, 0],
+  )
+
+  offs_m = (
+    pid_m * BLOCK_SIZE_M
+    + gl.arange(
+      0, BLOCK_SIZE_M, layout=gl.SliceLayout(0, gl.SliceLayout(2, blocked_kmn))
+    )
+  ) % M
+  offs_n = (
+    pid_n * BLOCK_SIZE_N
+    + gl.arange(
+      0, BLOCK_SIZE_N, layout=gl.SliceLayout(0, gl.SliceLayout(1, blocked_kmn))
+    )
+  ) % N
+  offs_k = gl.arange(
+    0, MAX_KSPLIT, layout=gl.SliceLayout(1, gl.SliceLayout(2, blocked_kmn))
+  )
+  c_in_ptrs = (
+    c_in_ptr
+    + (offs_k[:, None, None] * stride_c_in_k)
+    + (offs_m[None, :, None] * stride_c_in_m)
+    + (offs_n[None, None, :] * stride_c_in_n)
+  )
+
+  if ACTUAL_KSPLIT == MAX_KSPLIT:
+    c = gl.load(c_in_ptrs)
+  else:
+    c = gl.load(c_in_ptrs, mask=offs_k[:, None, None] < ACTUAL_KSPLIT)
+  c = gl.sum(c, axis=0)
+
+  c = c.to(c_out_ptr.type.element_ty)
+  offs_m = (
+    pid_m * BLOCK_SIZE_M
+    + gl.arange(0, BLOCK_SIZE_M, layout=gl.SliceLayout(1, blocked_mn))
+  ) % M
+  offs_n = (
+    pid_n * BLOCK_SIZE_N
+    + gl.arange(0, BLOCK_SIZE_N, layout=gl.SliceLayout(0, blocked_mn))
+  ) % N
+  c_out_ptrs = (
+    c_out_ptr + (offs_m[:, None] * stride_c_out_m) + (offs_n[None, :] * stride_c_out_n)
+  )
+  c = gl.convert_layout(c, layout=blocked_mn, assert_trivial=False)
+  gl.store(c_out_ptrs, c)
+
+
+@functools.lru_cache(maxsize=1024)
+def _get_config(
+  M: int,
+  N: int,
+  K: int,
+):
+  if not hasattr(_get_config, "_config_dict"):
+    dev = arch_info.get_arch()
+    if dev != "gfx950":
+      raise ValueError(
+        "Gluon implementation is not supported on this device (requires CDNA4)."
+      )
+    fpath = f"{_aiter.AITER_TRITON_CONFIGS_PATH}/gemm/gluon/{dev}-GEMM-AFP4WFP4.json"
+    with open(fpath, "r") as file:
+      config = json.load(file)
+    _get_config._config_dict = config
+
+  return _get_config._config_dict["any"]
+
+
+def gemm_afp4wfp4(
+  x: StridedArray,
+  w: StridedArray,
+  x_scales: StridedArray,
+  w_scales: StridedArray,
+  dtype: Optional[jnp.dtype] = jnp.bfloat16,
+  config: Optional[dict] = None,
+  skip_reduce: Optional[bool] = False,
+) -> jnp.ndarray:
+  """Computes matrix multiplication Y = X @ W^T with FP4 activations and FP4 weights.
+
+  This launcher trusts its inputs: it neither inspects the underlying buffer
+  orientation nor copies any tensor for layout reasons. The caller is responsible
+  for delivering each operand with the strides expected by the kernel below;
+  precondition assertions in the launcher will fail loud if that contract is broken.
+
+  The only stride-affecting operation the launcher performs is the ``w = w.T``
+  that has always been part of its API contract; this is implemented as a
+  zero-copy Python tuple swap on the wrapper's strides before they are passed
+  into the private jitted inner.
+
+  Per-operand layout precondition (on the wrapper's logical view, with strides in
+  element units):
+
+      x.shape          == (M, K // 2)             ; x.strides        == (K // 2, 1)
+      w.shape          == (N, K // 2)             ; w.strides        == (K // 2, 1)   (pre-T)
+      x_scales.shape   == (M, K // SCALE_GROUP_SIZE)
+                                                  ; x_scales.strides[0] == 1
+      w_scales.shape   == (N, K // SCALE_GROUP_SIZE)
+                                                  ; w_scales.strides[0] == 1
+
+  After the internal w = w.T the kernel sees w with shape (K // 2, N) and strides
+  (1, K // 2), i.e. K unit-stride. The kernel-tile register layouts (blocked_mk,
+  blocked_kn, blocked_scales) are tuned for exactly these orientations.
+
+  Args:
+      x: FP4 E2M1 activation matrix wrapper, logical shape (M, K // 2),
+          K unit-stride.
+      w: FP4 E2M1 weight matrix wrapper, logical shape (N, K // 2), K unit-stride.
+          Internally flipped to (K // 2, N) before the kernel call via a stride
+          tuple swap.
+      x_scales: E8M0 per-group scales for x, logical shape (M, K // 32),
+          M unit-stride. One scale per 32 elements in the K dimension.
+      w_scales: E8M0 per-group scales for w, logical shape (N, K // 32),
+          N unit-stride.
+      dtype: Output dtype (jnp.bfloat16 or jnp.float16).
+      config: Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
+          BLOCK_SIZE_K, GROUP_SIZE_M, NUM_KSPLIT, SPLITK_BLOCK_SIZE).
+      skip_reduce: If True and NUM_KSPLIT > 1, returns the partial-reduction
+          tensor of shape (NUM_KSPLIT, M, N).
+
+  Returns:
+      The output tensor with shape (M, N), or (NUM_KSPLIT, M, N) when
+      ``skip_reduce`` is True with NUM_KSPLIT > 1.
+
+  Raises:
+      AssertionError: If any input violates the layout precondition.
+  """
+  assert arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
+
+  M, K2 = x.shape
+  N, K2_w = w.shape
+  assert K2 == K2_w, f"K mismatch: x.shape[1]={K2}, w.shape[1]={K2_w}"
+  K = K2 * 2
+
+  assert x.strides == (K2, 1), f"x.strides={x.strides}; expected ({K2}, 1)"
+  assert w.strides == (K2, 1), f"w.strides={w.strides}; expected ({K2}, 1) (pre-T)"
+  assert x_scales.shape == (M, K // 32)
+  assert w_scales.shape == (N, K // 32)
+  assert x_scales.strides[0] == 1, (
+    f"x_scales.strides={x_scales.strides}; expected strides[0]==1"
+  )
+  assert w_scales.strides[0] == 1, (
+    f"w_scales.strides={w_scales.strides}; expected strides[0]==1"
+  )
+
+  w_strides_post_T = (w.strides[1], w.strides[0])
+
+  return _gemm_afp4wfp4_jit(
+    x.data,
+    w.data,
+    x_scales.data,
+    w_scales.data,
+    x_strides=x.strides,
+    w_strides=w_strides_post_T,
+    x_scales_strides=x_scales.strides,
+    w_scales_strides=w_scales.strides,
+    dtype=dtype,
+    config=config,
+    skip_reduce=skip_reduce,
+  )
+
+
+@functools.partial(
+  jax.jit,
+  static_argnames=(
+    "x_strides",
+    "w_strides",
+    "x_scales_strides",
+    "w_scales_strides",
+    "dtype",
+    "config",
+    "skip_reduce",
+  ),
+)
+def _gemm_afp4wfp4_jit(
+  x_data: jnp.ndarray,
+  w_data: jnp.ndarray,
+  x_scales_data: jnp.ndarray,
+  w_scales_data: jnp.ndarray,
+  *,
+  x_strides: Tuple[int, int],
+  w_strides: Tuple[int, int],
+  x_scales_strides: Tuple[int, int],
+  w_scales_strides: Tuple[int, int],
+  dtype: jnp.dtype,
+  config: Optional[dict],
+  skip_reduce: bool,
+) -> jnp.ndarray:
+  """Private jitted launcher; layout contract validated by gemm_afp4wfp4."""
+
+  M, K = x_data.shape
+  N = w_data.shape[0]
+
+  if config is None:
+    config = _get_config(M, N, K)
+
+  if config["BLOCK_SIZE_K"] >= K * 2:
+    config["NUM_KSPLIT"] = 1
+
+  assert config["NUM_KSPLIT"] >= 1
+  unit_NUM_KSPLIT = config["NUM_KSPLIT"] == 1
+
+  if not unit_NUM_KSPLIT:
+    SPLITK_BLOCK_SIZE = (
+      triton.cdiv((2 * triton.cdiv(K, config["NUM_KSPLIT"])), config["BLOCK_SIZE_K"])
+      * config["BLOCK_SIZE_K"]
+    )
+  else:
+    SPLITK_BLOCK_SIZE = 2 * K
+
+  config["SPLITK_BLOCK_SIZE"] = SPLITK_BLOCK_SIZE
+
+  if not unit_NUM_KSPLIT:
+    y_pp_shape = (config["NUM_KSPLIT"], M, N)
+    y_pp_dtype = dtype if _USE_GEMM_SPLITK_BF16 else jnp.float32
+    y_pp_stride = (y_pp_shape[1] * y_pp_shape[2], y_pp_shape[2], 1)
+  else:
+    y_pp, y_pp_stride, y_pp_shape, y_pp_dtype = None, None, None, None
+
+  y_shape = (M, N)
+
+  grid = lambda META: (  # noqa: E731
+    (
+      META["NUM_KSPLIT"]
+      * triton.cdiv(M, META["BLOCK_SIZE_M"])
+      * triton.cdiv(N, META["BLOCK_SIZE_N"])
+    ),
+  )
+
+  if unit_NUM_KSPLIT:
+    out_tensor_y_shape = y_shape
+    out_tensor_y_dtype = dtype
+  else:
+    out_tensor_y_shape = y_pp_shape
+    out_tensor_y_dtype = y_pp_dtype
+
+  result = jt.triton_call(
+    x_data,
+    w_data,
+    x_scales_data,
+    w_scales_data,
+    M,
+    N,
+    K,
+    x_strides[0],
+    x_strides[1],
+    w_strides[0],
+    w_strides[1],
+    0 if unit_NUM_KSPLIT else y_pp_stride[0],
+    y_shape[1] if unit_NUM_KSPLIT else y_pp_stride[1],
+    1 if unit_NUM_KSPLIT else y_pp_stride[2],
+    x_scales_strides[0],
+    x_scales_strides[1],
+    w_scales_strides[0],
+    w_scales_strides[1],
+    kernel=_gemm_afp4wfp4_kernel,
+    out_shape=jax.ShapeDtypeStruct(shape=out_tensor_y_shape, dtype=out_tensor_y_dtype),
+    grid=grid,
+    **config,
+  )
+
+  if unit_NUM_KSPLIT:
+    y = result
+  else:
+    y_pp = result
+    if skip_reduce:
+      return y_pp
+
+    REDUCE_BLOCK_SIZE_M = 16
+    REDUCE_BLOCK_SIZE_N = 128 if _USE_GEMM_SPLITK_BF16 else 64
+    ACTUAL_KSPLIT = triton.cdiv(K, (config["SPLITK_BLOCK_SIZE"] // 2))
+
+    grid_reduce = (
+      triton.cdiv(M, REDUCE_BLOCK_SIZE_M),
+      triton.cdiv(N, REDUCE_BLOCK_SIZE_N),
+    )
+
+    y = jt.triton_call(
+      y_pp,
+      M,
+      N,
+      y_pp_stride[0],
+      y_pp_stride[1],
+      y_pp_stride[2],
+      y_shape[1],  # y.stride(0),
+      1,  # y.stride(1),
+      kernel=_gemm_afp4wfp4_reduce_kernel,
+      out_shape=jax.ShapeDtypeStruct(shape=y_shape, dtype=dtype),
+      grid=grid_reduce,
+      BLOCK_SIZE_M=REDUCE_BLOCK_SIZE_M,
+      BLOCK_SIZE_N=REDUCE_BLOCK_SIZE_N,
+      ACTUAL_KSPLIT=ACTUAL_KSPLIT,
+      MAX_KSPLIT=triton.next_power_of_2(config["NUM_KSPLIT"]),
+    )
+
+  return y
+
+
+def gemm_afp4wfp4_from_arrays(x, w, x_scales, w_scales, *args, **kwargs):
+  """Convenience adapter for callers that have raw jnp.ndarray.
+
+  The same layout contract documented on gemm_afp4wfp4 still applies; this helper
+  only saves the caller from writing StridedArray.from_array four times. No data
+  is copied. If the raw arrays are not in the kernel-optimal orientation, the
+  launcher's contract assertions will fail.
+  """
+  return gemm_afp4wfp4(
+    StridedArray.from_array(x),
+    StridedArray.from_array(w),
+    StridedArray.from_array(x_scales),
+    StridedArray.from_array(w_scales),
+    *args,
+    **kwargs,
+  )

--- a/AMD/gemm_afp4wfp4_test.py
+++ b/AMD/gemm_afp4wfp4_test.py
@@ -1,0 +1,261 @@
+import sys
+
+import pytest
+
+import jax.numpy as jnp
+from jax import random
+import numpy as np
+
+import arch_info
+from gemm_afp4wfp4_gluon import gemm_afp4wfp4 as gluon_gemm_afp4wfp4
+from gemm_afp4wfp4_triton import gemm_afp4wfp4 as triton_gemm_afp4wfp4
+from strided_array import StridedArray
+
+# based on https://github.com/ROCm/aiter/blob/7411c99753f0661a3eecdbdb1b36feb58539f62b/aiter/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+
+
+# Note this is specified by the HW and cannot be changed.
+SCALE_GROUP_SIZE = 32
+
+
+def generate_gemm_afp4wfp4_inputs(
+  M,
+  N,
+  K,
+  dtype,
+  layout="TN",
+  output=True,
+  key=random.key(5),
+):
+  assert not isinstance(dtype, str)
+
+  def _randint(key, shape, lo, hi, dtype):
+    key, sub = random.split(key)
+    return key, random.randint(sub, shape, lo, hi, dtype=dtype)
+
+  if layout[0] == "T":
+    key, x_low = _randint(key, (M, K // 2), 0, 16, jnp.uint8)
+    key, x_high = _randint(key, (M, K // 2), 0, 16, jnp.uint8)
+    x_data = x_high << 4 | x_low
+    x = StridedArray.from_array(x_data)
+  else:
+    key, x_low = _randint(key, (K // 2, M), 0, 16, jnp.uint8)
+    key, x_high = _randint(key, (K // 2, M), 0, 16, jnp.uint8)
+    x_swapped = x_high << 4 | x_low
+    x_data = StridedArray.from_array(x_swapped).T.to_jax()
+    x = StridedArray.from_array(x_data)
+
+  if layout[1] == "N":
+    key, w_low = _randint(key, (N, K // 2), 0, 16, jnp.uint8)
+    key, w_high = _randint(key, (N, K // 2), 0, 16, jnp.uint8)
+    w_data = w_low | w_high << 4
+    w = StridedArray.from_array(w_data)
+  else:
+    key, w_low = _randint(key, (K // 2, N), 0, 16, jnp.uint8)
+    key, w_high = _randint(key, (K // 2, N), 0, 16, jnp.uint8)
+    w_swapped = w_low | w_high << 4
+    w_data = StridedArray.from_array(w_swapped).T.to_jax()
+    w = StridedArray.from_array(w_data)
+
+  M_pad = (M + 255) // 256 * 256
+  key, xs_data = _randint(key, (K // SCALE_GROUP_SIZE, M_pad), 124, 128, jnp.uint8)
+  key, ws_data = _randint(key, (K // SCALE_GROUP_SIZE, N), 124, 128, jnp.uint8)
+
+  x_scales = StridedArray.from_array(xs_data).T[:M]
+  w_scales = StridedArray.from_array(ws_data).T
+
+  x_scales_shuffled = x_scales
+  w_scales_shuffled = w_scales
+
+  w_shuffled = w
+
+  return (
+    x,
+    w,
+    w_shuffled,  # w_triton
+    x_scales,  # x_scales
+    w_scales,  # w_scales
+    x_scales_shuffled,  # x_scales_triton
+    w_scales_shuffled,  # w_scales_triton
+  )
+
+
+def get_x_vals():
+  x_vals = [(1024 * v, 1024 * v, 1024 * v) for v in range(1, 9)]
+  x_vals += [(4864, 4096, 8192), (9728, 8192, 65536), (4864, 8192, 4160)]
+  x_vals += [
+    (1, 1280, 8192),
+    (32, 1280, 8192),
+    (64, 1280, 8192),
+    (128, 1280, 8192),
+    (192, 1280, 8192),
+    (256, 1280, 8192),
+    (320, 1280, 8192),
+    (512, 1280, 8192),
+    (1024, 1280, 8192),
+    (2048, 1280, 8192),
+    (4096, 1280, 8192),
+    (8192, 1280, 8192),
+    (16384, 1280, 8192),
+    (1, 8192, 1024),
+    (32, 8192, 1024),
+    (64, 8192, 1024),
+    (128, 8192, 1024),
+    (192, 8192, 1024),
+    (256, 8192, 1024),
+    (320, 8192, 1024),
+    (512, 8192, 1024),
+    (1024, 8192, 1024),
+    (2048, 8192, 1024),
+    (4096, 8192, 1024),
+    (8192, 8192, 1024),
+    (16384, 8192, 1024),
+  ]
+  x_vals += [(2 ** (v - 1), 4096 * v, 4096 * v) for v in range(1, 6)]
+  # x_vals = [(128, 1024, 4096)]
+  x_vals += [(16, 16384, 3328 * 2), (128, 16384, 3328 * 2)]
+  x_vals += [(256, 3584, 2112)]
+  x_vals += [(7, 4608, 7168), (7, 7168, 2304)]
+  x_vals += [(v, 106496, 16384) for v in [1, 8, 16, 32, 64, 128, 256]]
+  x_vals += [(v, 16384, 53248) for v in [1, 8, 16, 32, 64, 128, 256]]
+  x_vals += [(v, 18432, 16384) for v in [1, 8, 16, 32, 64, 128, 256]]
+  x_vals += [(v, 16384, 16384) for v in [1, 8, 16, 32, 64, 128, 256]]
+  x_vals += [(v, 10240, 8192) for v in [1, 2, 4, 8, 16, 32, 64]]
+  x_vals += [(v, 8192, 8192) for v in [1, 2, 4, 8, 16, 32, 64]]
+  x_vals += [(v, 57344, 8192) for v in [1, 2, 4, 8, 16, 32, 64]]
+  x_vals += [(v, 8192, 28672) for v in [1, 2, 4, 8, 16, 32, 64]]
+  x_vals += [(1, 1, 32)]  # minimal case
+  return x_vals
+  # return [(128, 1280, 8192)]
+
+
+def mxfp4_to_f32(x):
+  # 2 because we pack fp4 in uint8.
+  x = jnp.repeat(x, 2, axis=1)
+  x = x.at[:, ::2].set(x[:, ::2] & 0xF)
+  x = x.at[:, 1::2].set(x[:, 1::2] >> 4)
+  mxfp4_list = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+  ]
+  mxfp4_in_f32 = jnp.array(mxfp4_list, dtype=jnp.float32)
+  return mxfp4_in_f32[x.astype(jnp.int32)]
+
+
+def e8m0_to_f32(x):
+  x_f32 = 2 ** (x.astype(jnp.float32) - 127)
+  # WARNING! The original implementation:
+  # x_f32[x_f32 == 128] = float("nan")
+  # has a bug: it must map the original x==255 to a NaN, instead it left x_f32 poisoned
+  # with inf <= 2**(255-127) == 2**128, but remaps legitimate x==134 or
+  # x_f32==2**(134-127)==2**7==128 to NaN
+  x_f32 = x_f32.at[x == 255].set(jnp.nan)
+  return x_f32
+
+
+def jax_afp4wfp4(x, w, x_scales, w_scales, dtype):
+  # First convert the x and w inputs to f32.
+  x_f32 = mxfp4_to_f32(x)
+  w_f32 = mxfp4_to_f32(w)
+  # Next convert the e8m0 scales to f32.
+
+  x_scales = jnp.repeat(x_scales, SCALE_GROUP_SIZE, axis=1).astype(jnp.float32)
+
+  x_scales_f32 = e8m0_to_f32(x_scales)
+  x_f32 = x_f32 * x_scales_f32
+  w_scales = jnp.repeat(w_scales, SCALE_GROUP_SIZE, axis=1).astype(jnp.float32)
+  w_scales_f32 = e8m0_to_f32(w_scales)
+  w_f32 = w_f32 * w_scales_f32
+  return jnp.matmul(x_f32, w_f32.T).astype(dtype)
+
+
+def run_triton(
+  x, w, x_scales, w_scales, dtype=jnp.bfloat16, skip_reduce=False, impl=None
+):
+  return impl(x, w, x_scales, w_scales, dtype, skip_reduce=skip_reduce)
+
+
+@pytest.mark.parametrize("M, N, K", get_x_vals())
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+@pytest.mark.parametrize("layout", ["TN", "TT", "NN", "NT"])
+@pytest.mark.parametrize("output", [True, False])
+@pytest.mark.parametrize("shuffle_weight_scales", [False])  #  [True, False], )
+@pytest.mark.parametrize("skip_reduce", [True, False])
+@pytest.mark.parametrize("impl", ["triton", "gluon"])
+def test_gemm_afp4_wfp4(
+  M: int,
+  N: int,
+  K: int,
+  dtype,
+  layout,
+  output,
+  shuffle_weight_scales,
+  skip_reduce,
+  impl,
+):
+  del shuffle_weight_scales  # unused. Left for compatibility with the original test
+  if not arch_info.is_fp4_avail():
+    pytest.skip("MXFP4 not supported on this architecture (requires CDNA4).")
+
+  (
+    x,
+    w,
+    w_triton,
+    x_scales,
+    w_scales,
+    x_scales_triton,
+    w_scales_triton,
+  ) = generate_gemm_afp4wfp4_inputs(M, N, K, dtype, layout=layout, output=output)
+
+  expected = jax_afp4wfp4(
+    x.to_jax(),
+    w.to_jax(),
+    x_scales.to_jax(),
+    w_scales.to_jax(),
+    dtype,
+  )
+
+  if impl == "triton":
+    impl = triton_gemm_afp4wfp4
+  elif impl == "gluon":
+    impl = gluon_gemm_afp4wfp4
+  else:
+    raise ValueError(f"Unknown implementation: {impl}")
+
+  triton_out = run_triton(
+    x,
+    w_triton,
+    x_scales_triton,
+    w_scales_triton,
+    dtype,
+    skip_reduce=skip_reduce,
+    impl=impl,
+  )
+
+  if triton_out.ndim == 3:
+    triton_out = triton_out.sum(axis=0).astype(dtype)
+
+  # torch.testing.assert_close(torch_out, triton_out)
+  # https://docs.pytorch.org/docs/stable/testing.html#torch.testing.assert_close
+  rtol = {jnp.float16: 1e-3, jnp.bfloat16: 1.6e-2}
+  atol = {jnp.float16: 1e-5, jnp.bfloat16: 1e-5}
+
+  np.testing.assert_allclose(triton_out, expected, rtol=rtol[dtype], atol=atol[dtype])
+
+
+if __name__ == "__main__":
+  sys.exit(pytest.main(sys.argv))

--- a/AMD/gemm_afp4wfp4_triton.py
+++ b/AMD/gemm_afp4wfp4_triton.py
@@ -1,0 +1,541 @@
+# based on https://github.com/ROCm/aiter/blob/7411c99753f0661a3eecdbdb1b36feb58539f62b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
+# Kernels were copypasted and output pointer was moved to the last position.
+# The launch function was rewritten to use JAX primitives and match jax-triton calling
+# conventions
+
+import functools
+from typing import Optional, Tuple
+
+from strided_array import StridedArray
+
+import triton
+import triton.language as tl
+
+import _aiter
+import arch_info
+import jax
+import jax.numpy as jnp
+import jax_triton as jt
+
+
+@triton.heuristics({
+  "EVEN_K": lambda args: (
+    (args["K"] % (args["BLOCK_SIZE_K"] // 2) == 0)
+    and (args["SPLITK_BLOCK_SIZE"] % args["BLOCK_SIZE_K"] == 0)
+    and (args["K"] % (args["SPLITK_BLOCK_SIZE"] // 2) == 0)
+  ),
+})
+@triton.jit
+def _gemm_afp4wfp4_kernel(
+  a_ptr,
+  b_ptr,
+  # c_ptr,
+  a_scales_ptr,
+  b_scales_ptr,
+  M,
+  N,
+  K,
+  stride_am,
+  stride_ak,
+  stride_bk,
+  stride_bn,
+  stride_ck,
+  stride_cm,
+  stride_cn,
+  stride_asm,
+  stride_ask,
+  stride_bsn,
+  stride_bsk,
+  c_ptr,  # output goes last
+  # Meta-parameters
+  BLOCK_SIZE_M: tl.constexpr,
+  BLOCK_SIZE_N: tl.constexpr,
+  BLOCK_SIZE_K: tl.constexpr,
+  GROUP_SIZE_M: tl.constexpr,
+  NUM_KSPLIT: tl.constexpr,
+  SPLITK_BLOCK_SIZE: tl.constexpr,
+  EVEN_K: tl.constexpr,
+  num_warps: tl.constexpr,
+  num_stages: tl.constexpr,
+  waves_per_eu: tl.constexpr,
+  matrix_instr_nonkdim: tl.constexpr,
+  cache_modifier: tl.constexpr,
+):
+  """
+  Kernel for computing the matmul C = A x B.
+  A and B inputs are in the microscale fp4 (mxfp4) format.
+  A_scales and B_scales are in e8m0 format.
+  A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+  """
+
+  tl.assume(stride_am > 0)
+  tl.assume(stride_ak > 0)
+  tl.assume(stride_bk > 0)
+  tl.assume(stride_bn > 0)
+  tl.assume(stride_cm > 0)
+  tl.assume(stride_cn > 0)
+  tl.assume(stride_asm > 0)
+  tl.assume(stride_ask > 0)
+  tl.assume(stride_bsk > 0)
+  tl.assume(stride_bsn > 0)
+
+  GRID_MN = tl.cdiv(M, BLOCK_SIZE_M) * tl.cdiv(N, BLOCK_SIZE_N)
+
+  # -----------------------------------------------------------
+  # Map program ids `pid` to the block of C it should compute.
+  # This is done in a grouped ordering to promote L2 data reuse.
+  pid_unified = tl.program_id(axis=0)
+  # remap so that XCDs get continous chunks of pids (of CHUNK_SIZE).
+  pid_unified = _aiter.remap_xcd(pid_unified, GRID_MN * NUM_KSPLIT, NUM_XCDS=8)
+
+  pid_k = pid_unified % NUM_KSPLIT
+  pid = pid_unified // NUM_KSPLIT
+  num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+  num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+  if NUM_KSPLIT == 1:
+    pid_m, pid_n = _aiter.pid_grid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M=GROUP_SIZE_M)
+  else:
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+  tl.assume(pid_m >= 0)
+  tl.assume(pid_n >= 0)
+  tl.assume(pid_k >= 0)
+  # We assume 32 elements along K share the same scale.
+  SCALE_GROUP_SIZE: tl.constexpr = 32
+
+  if (pid_k * SPLITK_BLOCK_SIZE // 2) < K:
+    num_k_iter = tl.cdiv(SPLITK_BLOCK_SIZE // 2, BLOCK_SIZE_K // 2)
+
+    # Create pointers for first block of A and B input matrices
+    # The BLOCK sizes are of the elements and in fp4 we pack 2 per uint8 container.
+    offs_k = tl.arange(0, BLOCK_SIZE_K // 2)
+    offs_k_split = pid_k * (SPLITK_BLOCK_SIZE // 2) + offs_k
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k_split[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k_split[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    # Create pointers for the first block of A and B scales
+    offs_ks = (pid_k * (SPLITK_BLOCK_SIZE // SCALE_GROUP_SIZE)) + tl.arange(
+      0, BLOCK_SIZE_K // SCALE_GROUP_SIZE
+    )
+    a_scale_ptrs = (
+      a_scales_ptr + offs_am[:, None] * stride_asm + offs_ks[None, :] * stride_ask
+    )
+    # B scales are N x K even though B operand is K x N.
+    b_scale_ptrs = (
+      b_scales_ptr + offs_bn[:, None] * stride_bsn + offs_ks[None, :] * stride_bsk
+    )
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
+      # When EVEN_K is true, K / SG is an exact multiple of (BLOCK_SIZE_K / SG),
+      # so the scale-pointer arithmetic stays in-bounds and the unconditional
+      # tl.load matches the register layout tl.dot_scaled expects.
+      # When EVEN_K is false, the tail K-iteration overshoots the scale buffer
+      # in the K-scale axis. We mask out those lanes to avoid reading 0xFF bytes
+      # (which decode as e8m0 NaN) from past-the-end memory.
+      if EVEN_K:
+        a_scales = tl.load(a_scale_ptrs)
+        b_scales = tl.load(b_scale_ptrs, cache_modifier=cache_modifier)
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs, cache_modifier=cache_modifier)
+      else:
+        k_scale_mask = offs_ks < (2 * K // SCALE_GROUP_SIZE) - k * (
+          BLOCK_SIZE_K // SCALE_GROUP_SIZE
+        )
+        a_scales = tl.load(a_scale_ptrs, mask=k_scale_mask[None, :], other=0)
+        b_scales = tl.load(
+          b_scale_ptrs,
+          mask=k_scale_mask[None, :],
+          other=0,
+          cache_modifier=cache_modifier,
+        )
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * (BLOCK_SIZE_K // 2), other=0)
+        b = tl.load(
+          b_ptrs,
+          mask=offs_k[:, None] < K - k * (BLOCK_SIZE_K // 2),
+          other=0,
+          cache_modifier=cache_modifier,
+        )
+
+      accumulator = tl.dot_scaled(a, a_scales, "e2m1", b, b_scales, "e2m1", accumulator)
+
+      # Advance the ptrs to the next K block.
+      a_ptrs += (BLOCK_SIZE_K // 2) * stride_ak
+      b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+      a_scale_ptrs += (BLOCK_SIZE_K // SCALE_GROUP_SIZE) * stride_ask
+      b_scale_ptrs += (BLOCK_SIZE_K // SCALE_GROUP_SIZE) * stride_bsk
+
+    c = accumulator.to(c_ptr.type.element_ty)
+
+    # Write back the block of the output matrix C with masks.
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    c_ptrs = (
+      c_ptr
+      + stride_cm * offs_cm[:, None]
+      + stride_cn * offs_cn[None, :]
+      + pid_k * stride_ck
+    )
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+@triton.jit
+def _gemm_afp4wfp4_reduce_kernel(
+  c_in_ptr,
+  # c_out_ptr,
+  M,
+  N,
+  stride_c_in_k,
+  stride_c_in_m,
+  stride_c_in_n,
+  stride_c_out_m,
+  stride_c_out_n,
+  c_out_ptr,  # output goes last
+  BLOCK_SIZE_M: tl.constexpr,
+  BLOCK_SIZE_N: tl.constexpr,
+  ACTUAL_KSPLIT: tl.constexpr,
+  MAX_KSPLIT: tl.constexpr,
+):
+
+  pid_m = tl.program_id(axis=0)
+  pid_n = tl.program_id(axis=1)
+
+  offs_m = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+  offs_n = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+  offs_k = tl.arange(0, MAX_KSPLIT)
+  c_in_ptrs = (
+    c_in_ptr
+    + (offs_k[:, None, None] * stride_c_in_k)
+    + (offs_m[None, :, None] * stride_c_in_m)
+    + (offs_n[None, None, :] * stride_c_in_n)
+  )
+
+  if ACTUAL_KSPLIT == MAX_KSPLIT:
+    c = tl.load(c_in_ptrs)
+  else:
+    c = tl.load(c_in_ptrs, mask=offs_k[:, None, None] < ACTUAL_KSPLIT)
+  c = tl.sum(c, axis=0)
+
+  c = c.to(c_out_ptr.type.element_ty)
+
+  c_out_ptrs = (
+    c_out_ptr + (offs_m[:, None] * stride_c_out_m) + (offs_n[None, :] * stride_c_out_n)
+  )
+
+  tl.store(c_out_ptrs, c)
+
+
+def _get_config(
+  M: int,
+  N: int,
+  K: int,
+  shuffle: bool = False,
+):
+  # Note: Config files use K=2*K in their naming
+  K = 2 * K
+  if shuffle:
+    return _aiter.get_gemm_config("GEMM-AFP4WFP4_PRESHUFFLED", M, N, K)
+  else:
+    return _aiter.get_gemm_config("GEMM-AFP4WFP4", M, N, K)
+
+
+def get_splitk(K: int, BLOCK_SIZE_K: int, NUM_KSPLIT: int):
+  # heuristics for make "EVEN_K == True" as much as possible
+  NUM_KSPLIT_STEP = 2
+  BLOCK_SIZE_K_STEP = 2
+  SPLITK_BLOCK_SIZE = (
+    triton.cdiv((2 * triton.cdiv(K, NUM_KSPLIT)), BLOCK_SIZE_K) * BLOCK_SIZE_K
+  )
+  while NUM_KSPLIT > 1 and BLOCK_SIZE_K > 16:
+    if (
+      K % (SPLITK_BLOCK_SIZE // 2) == 0
+      and SPLITK_BLOCK_SIZE % BLOCK_SIZE_K == 0
+      and K % (BLOCK_SIZE_K // 2) == 0
+    ):
+      break
+    elif K % (SPLITK_BLOCK_SIZE // 2) != 0 and NUM_KSPLIT > 1:
+      NUM_KSPLIT = NUM_KSPLIT // NUM_KSPLIT_STEP
+    elif SPLITK_BLOCK_SIZE % BLOCK_SIZE_K != 0:
+      if NUM_KSPLIT > 1:
+        NUM_KSPLIT = NUM_KSPLIT // NUM_KSPLIT_STEP
+      elif BLOCK_SIZE_K > 16:
+        BLOCK_SIZE_K = BLOCK_SIZE_K // BLOCK_SIZE_K_STEP
+    elif K % (BLOCK_SIZE_K // 2) != 0 and BLOCK_SIZE_K > 16:
+      BLOCK_SIZE_K = BLOCK_SIZE_K // BLOCK_SIZE_K_STEP
+    else:
+      break
+
+    SPLITK_BLOCK_SIZE = (
+      triton.cdiv((2 * triton.cdiv(K, NUM_KSPLIT)), BLOCK_SIZE_K) * BLOCK_SIZE_K
+    )
+
+  # re-ensuring NUM_KSPLIT is the correct value
+  NUM_KSPLIT = triton.cdiv(K, (SPLITK_BLOCK_SIZE // 2))
+
+  return SPLITK_BLOCK_SIZE, BLOCK_SIZE_K, NUM_KSPLIT
+
+
+global _USE_GEMM_SPLITK_BF16
+_USE_GEMM_SPLITK_BF16 = False
+
+
+def gemm_afp4wfp4(
+  x: StridedArray,
+  w: StridedArray,
+  x_scales: StridedArray,
+  w_scales: StridedArray,
+  dtype: Optional[jnp.dtype] = jnp.bfloat16,
+  config: Optional[dict] = None,
+  skip_reduce: Optional[bool] = False,
+) -> jnp.ndarray:
+  """Computes matrix multiplication Y = X @ W^T with FP4 activations and FP4 weights.
+
+  This launcher trusts its inputs: it neither inspects the underlying buffer
+  orientation nor copies any tensor for layout reasons. The caller is responsible
+  for delivering each operand with the strides expected by the kernel below;
+  precondition assertions in the launcher will fail loud if that contract is broken.
+
+  The only stride-affecting operation the launcher performs is the ``w = w.T``
+  that has always been part of its API contract; this is implemented as a
+  zero-copy Python tuple swap on the wrapper's strides before they are passed
+  into the private jitted inner.
+
+  Per-operand layout precondition (on the wrapper's logical view, with strides in
+  element units):
+
+      x.shape          == (M, K // 2)             ; x.strides        == (K // 2, 1)
+      w.shape          == (N, K // 2)             ; w.strides        == (K // 2, 1)   (pre-T)
+      x_scales.shape   == (M, K // SCALE_GROUP_SIZE)
+                                                  ; x_scales.strides[0] == 1
+      w_scales.shape   == (N, K // SCALE_GROUP_SIZE)
+                                                  ; w_scales.strides[0] == 1
+
+  After the internal w = w.T the kernel sees w with shape (K // 2, N) and strides
+  (1, K // 2), i.e. K unit-stride. The kernel-tile register layouts (blocked_mk,
+  blocked_kn, blocked_scales) are tuned for exactly these orientations.
+
+  Args:
+      x: FP4 E2M1 activation matrix wrapper, logical shape (M, K // 2),
+          K unit-stride.
+      w: FP4 E2M1 weight matrix wrapper, logical shape (N, K // 2), K unit-stride.
+          Internally flipped to (K // 2, N) before the kernel call via a stride
+          tuple swap.
+      x_scales: E8M0 per-group scales for x, logical shape (M, K // 32),
+          M unit-stride. One scale per 32 elements in the K dimension.
+      w_scales: E8M0 per-group scales for w, logical shape (N, K // 32),
+          N unit-stride.
+      dtype: Output dtype (jnp.bfloat16 or jnp.float16).
+      config: Kernel tuning parameters (BLOCK_SIZE_M, BLOCK_SIZE_N,
+          BLOCK_SIZE_K, GROUP_SIZE_M, NUM_KSPLIT, SPLITK_BLOCK_SIZE).
+      skip_reduce: If True and NUM_KSPLIT > 1, returns the partial-reduction
+          tensor of shape (NUM_KSPLIT, M, N).
+
+  Returns:
+      The output tensor with shape (M, N), or (NUM_KSPLIT, M, N) when
+      ``skip_reduce`` is True with NUM_KSPLIT > 1.
+
+  Raises:
+      AssertionError: If any input violates the layout precondition.
+  """
+  assert arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
+
+  M, K2 = x.shape
+  N, K2_w = w.shape
+  assert K2 == K2_w, f"K mismatch: x.shape[1]={K2}, w.shape[1]={K2_w}"
+  K = K2 * 2
+
+  assert x.strides == (K2, 1), f"x.strides={x.strides}; expected ({K2}, 1)"
+  assert w.strides == (K2, 1), f"w.strides={w.strides}; expected ({K2}, 1) (pre-T)"
+  assert x_scales.shape == (M, K // 32)
+  assert w_scales.shape == (N, K // 32)
+  assert x_scales.strides[0] == 1, (
+    f"x_scales.strides={x_scales.strides}; expected strides[0]==1"
+  )
+  assert w_scales.strides[0] == 1, (
+    f"w_scales.strides={w_scales.strides}; expected strides[0]==1"
+  )
+
+  w_strides_post_T = (w.strides[1], w.strides[0])
+
+  return _gemm_afp4wfp4_jit(
+    x.data,
+    w.data,
+    x_scales.data,
+    w_scales.data,
+    x_strides=x.strides,
+    w_strides=w_strides_post_T,
+    x_scales_strides=x_scales.strides,
+    w_scales_strides=w_scales.strides,
+    dtype=dtype,
+    config=config,
+    skip_reduce=skip_reduce,
+  )
+
+
+@functools.partial(
+  jax.jit,
+  static_argnames=(
+    "x_strides",
+    "w_strides",
+    "x_scales_strides",
+    "w_scales_strides",
+    "dtype",
+    "config",
+    "skip_reduce",
+  ),
+)
+def _gemm_afp4wfp4_jit(
+  x_data: jnp.ndarray,
+  w_data: jnp.ndarray,
+  x_scales_data: jnp.ndarray,
+  w_scales_data: jnp.ndarray,
+  *,
+  x_strides: Tuple[int, int],
+  w_strides: Tuple[int, int],
+  x_scales_strides: Tuple[int, int],
+  w_scales_strides: Tuple[int, int],
+  dtype: jnp.dtype,
+  config: Optional[dict],
+  skip_reduce: bool,
+) -> jnp.ndarray:
+  """Private jitted launcher; layout contract validated by gemm_afp4wfp4."""
+
+  M, K = x_data.shape
+  N = w_data.shape[0]
+
+  if config is None:
+    config, _ = _get_config(M, N, K)
+
+  assert config["NUM_KSPLIT"] >= 1
+
+  if config["NUM_KSPLIT"] > 1:
+    SPLITK_BLOCK_SIZE, BLOCK_SIZE_K, NUM_KSPLIT = get_splitk(
+      K, config["BLOCK_SIZE_K"], config["NUM_KSPLIT"]
+    )
+
+    config["SPLITK_BLOCK_SIZE"] = SPLITK_BLOCK_SIZE
+    config["BLOCK_SIZE_K"] = BLOCK_SIZE_K
+    config["NUM_KSPLIT"] = NUM_KSPLIT
+
+  if config["BLOCK_SIZE_K"] >= 2 * K:
+    config["BLOCK_SIZE_K"] = triton.next_power_of_2(2 * K)
+    config["SPLITK_BLOCK_SIZE"] = 2 * K
+    config["NUM_KSPLIT"] = 1
+  config["BLOCK_SIZE_K"] = max(config["BLOCK_SIZE_K"], 128)
+
+  unit_NUM_KSPLIT = config["NUM_KSPLIT"] == 1
+  return_y_pp = not unit_NUM_KSPLIT and skip_reduce
+
+  if not unit_NUM_KSPLIT:
+    y_pp_shape = (config["NUM_KSPLIT"], M, N)
+    y_pp_dtype = dtype if _USE_GEMM_SPLITK_BF16 else jnp.float32
+    y_pp_stride = (y_pp_shape[1] * y_pp_shape[2], y_pp_shape[2], 1)
+  else:
+    config["SPLITK_BLOCK_SIZE"] = 2 * K
+    y_pp, y_pp_stride, y_pp_shape, y_pp_dtype = None, None, None, None
+
+  y_shape = (M, N)
+
+  # config["BLOCK_SIZE_N"] = max(config["BLOCK_SIZE_N"], 32)
+
+  grid = lambda META: (  # noqa: E731
+    (
+      META["NUM_KSPLIT"]
+      * triton.cdiv(M, META["BLOCK_SIZE_M"])
+      * triton.cdiv(N, META["BLOCK_SIZE_N"])
+    ),
+  )
+
+  if unit_NUM_KSPLIT:
+    out_tensor_y_shape = y_shape
+    out_tensor_y_dtype = dtype
+  else:
+    out_tensor_y_shape = y_pp_shape
+    out_tensor_y_dtype = y_pp_dtype
+
+  result = jt.triton_call(
+    x_data,
+    w_data,
+    x_scales_data,
+    w_scales_data,
+    M,
+    N,
+    K,
+    x_strides[0],
+    x_strides[1],
+    w_strides[0],
+    w_strides[1],
+    0 if unit_NUM_KSPLIT else y_pp_stride[0],
+    y_shape[1] if unit_NUM_KSPLIT else y_pp_stride[1],
+    1 if unit_NUM_KSPLIT else y_pp_stride[2],
+    x_scales_strides[0],
+    x_scales_strides[1],
+    w_scales_strides[0],
+    w_scales_strides[1],
+    kernel=_gemm_afp4wfp4_kernel,
+    out_shape=jax.ShapeDtypeStruct(shape=out_tensor_y_shape, dtype=out_tensor_y_dtype),
+    grid=grid,
+    **config,
+  )
+
+  if return_y_pp:
+    return result
+  elif not unit_NUM_KSPLIT:
+    y_pp = result
+    REDUCE_BLOCK_SIZE_M = 16
+    # TODO: Need to debug - REDUCE_BLOCK_SIZE_N=128 with fp32 partials fails
+    # NOTE: REDUCE_BLOCK_SIZE_N=16 gives best perf with fp32 partials and
+    # REDUCE_BLOCK_SIZE_N=128 gives best perf with bf16 partials
+    REDUCE_BLOCK_SIZE_N = 128 if _USE_GEMM_SPLITK_BF16 else 64
+    ACTUAL_KSPLIT = triton.cdiv(K, (config["SPLITK_BLOCK_SIZE"] // 2))
+
+    grid_reduce = (
+      triton.cdiv(M, REDUCE_BLOCK_SIZE_M),
+      triton.cdiv(N, REDUCE_BLOCK_SIZE_N),
+    )
+
+    y = jt.triton_call(
+      y_pp,
+      M,
+      N,
+      y_pp_stride[0],
+      y_pp_stride[1],
+      y_pp_stride[2],
+      y_shape[1],  # y.stride(0),
+      1,  # y.stride(1),
+      kernel=_gemm_afp4wfp4_reduce_kernel,
+      out_shape=jax.ShapeDtypeStruct(shape=y_shape, dtype=dtype),
+      grid=grid_reduce,
+      BLOCK_SIZE_M=REDUCE_BLOCK_SIZE_M,
+      BLOCK_SIZE_N=REDUCE_BLOCK_SIZE_N,
+      ACTUAL_KSPLIT=ACTUAL_KSPLIT,
+      MAX_KSPLIT=triton.next_power_of_2(config["NUM_KSPLIT"]),
+    )
+
+  else:
+    y = result
+
+  return y
+
+
+def gemm_afp4wfp4_from_arrays(x, w, x_scales, w_scales, *args, **kwargs):
+  """Convenience adapter for callers that have raw jnp.ndarray.
+
+  The same layout contract documented on gemm_afp4wfp4 still applies; this helper
+  only saves the caller from writing StridedArray.from_array four times. No data
+  is copied. If the raw arrays are not in the kernel-optimal orientation, the
+  launcher's contract assertions will fail.
+  """
+  return gemm_afp4wfp4(
+    StridedArray.from_array(x),
+    StridedArray.from_array(w),
+    StridedArray.from_array(x_scales),
+    StridedArray.from_array(w_scales),
+    *args,
+    **kwargs,
+  )

--- a/AMD/prepare_benchmarking.sh
+++ b/AMD/prepare_benchmarking.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+    echo "Error: Script must be sourced"
+    exit 1
+fi
+
+function setup_benchmarking() {
+    # Implemented here is gfx950 specific and likely incomplete, as it helps less than
+    # desirable. However, it's still better than nothing
+
+    # rocm-smi --setfan 100% # fan control isn't supported on gfx950
+    rocm-smi --setperfdeterminism 1600
+    #rocm-smi --setpoweroverdrive 900  # 1400W is gfx950 TDP. Note, setting too low would slowdown gluon!
+
+    #cpupower frequency-set -g performance
+    #sysctl kernel.numa_balancing=0
+}
+
+set -x
+
+export ROCR_VISIBLE_DEVICES=1
+
+setup_benchmarking
+
+rocm-smi --showperflevel
+
+set +x
+
+function teardown_benchmarking() {
+    set -x
+
+    unset ROCR_VISIBLE_DEVICES
+
+    rocm-smi --resetperfdeterminism --resetpoweroverdrive --resetfans --setperflevel auto
+    rocm-smi --showperflevel
+
+    set +x
+}
+
+echo "Benchmarking setup complete. To revert, run: teardown_benchmarking. To setup again, run: setup_benchmarking"

--- a/AMD/strided_array.py
+++ b/AMD/strided_array.py
@@ -1,0 +1,222 @@
+"""Plain-Python strided view over a contiguous jax.Array (test driver helper)."""
+
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+import jax
+import jax.numpy as jnp
+
+ShapeT = Tuple[int, ...]
+StrideT = Tuple[int, ...]
+
+IndexKey = Union[int, slice, Tuple[Union[int, slice], ...]]
+
+
+def default_strides(shape: ShapeT) -> StrideT:
+  if not shape:
+    return ()
+  stride = 1
+  strides: list[int] = []
+  for size in reversed(shape):
+    strides.insert(0, stride)
+    stride *= size
+  return tuple(strides)
+
+
+class StridedArray:
+  """Zero-copy stride/view wrapper over a C-contiguous jax.Array."""
+
+  data: jax.Array
+  shape: ShapeT
+  strides: StrideT
+  offset: int
+
+  def __init__(
+    self,
+    data: jax.Array,
+    shape: ShapeT | None = None,
+    strides: StrideT | None = None,
+    offset: int = 0,
+  ):
+    if shape is None:
+      shape = tuple(data.shape)
+    if strides is None:
+      strides = default_strides(shape)
+    if len(shape) != len(strides):
+      raise ValueError(
+        f"shape ndim {len(shape)} != strides ndim {len(strides)}"
+      )
+    if offset < 0:
+      raise ValueError(f"offset must be non-negative, got {offset}")
+    for s in strides:
+      if s < 0:
+        raise ValueError(f"strides must be non-negative, got {strides}")
+
+    self.data = data
+    self.shape = tuple(shape)
+    self.strides = tuple(strides)
+    self.offset = offset
+    self._validate_bounds()
+
+  def _validate_bounds(self) -> None:
+    if self.ndim == 0:
+      if self.offset >= self.data.size:
+        raise ValueError("offset out of bounds for scalar view")
+      return
+    max_linear = self.offset
+    for dim, (size, stride) in enumerate(zip(self.shape, self.strides)):
+      if size < 0:
+        raise ValueError(f"shape[{dim}] must be non-negative, got {size}")
+      if size > 0:
+        max_linear += (size - 1) * stride
+    if max_linear >= self.data.size:
+      raise ValueError(
+        f"view exceeds data.size={self.data.size} (max linear index {max_linear})"
+      )
+
+  @classmethod
+  def from_array(cls, data: jax.Array) -> StridedArray:
+    shape = tuple(data.shape)
+    return cls(data, shape=shape, strides=default_strides(shape), offset=0)
+
+  @property
+  def ndim(self) -> int:
+    return len(self.shape)
+
+  def stride(self, axis: int) -> int:
+    if axis < 0:
+      axis += self.ndim
+    if axis < 0 or axis >= self.ndim:
+      raise IndexError(f"axis {axis} out of range for ndim {self.ndim}")
+    return self.strides[axis]
+
+  @property
+  def dtype(self) -> jnp.dtype:
+    return self.data.dtype
+
+  @property
+  def T(self) -> StridedArray:
+    if self.ndim != 2:
+      raise NotImplementedError("T is only defined for 2-D arrays")
+    return self.transpose(1, 0)
+
+  def transpose(self, *axes: int) -> StridedArray:
+    if len(axes) != self.ndim:
+      raise ValueError(
+        f"transpose expects {self.ndim} axes, got {len(axes)}"
+      )
+    return StridedArray(
+      self.data,
+      shape=tuple(self.shape[i] for i in axes),
+      strides=tuple(self.strides[i] for i in axes),
+      offset=self.offset,
+    )
+
+  def __getitem__(self, key: IndexKey) -> StridedArray:
+    if isinstance(key, tuple):
+      if len(key) != self.ndim:
+        raise NotImplementedError(
+          f"tuple indexing with {len(key)} entries for ndim {self.ndim}"
+        )
+      result = self
+      for axis, k in enumerate(key):
+        result = result._index_axis(axis, k)
+      return result
+
+    return self._index_axis(0, key)
+
+  def _index_axis(self, axis: int, key: Union[int, slice]) -> StridedArray:
+    if axis != 0:
+      raise NotImplementedError("only outer-axis indexing is supported")
+
+    if isinstance(key, slice):
+      if key.start not in (None, 0) or key.step not in (None, 1):
+        raise NotImplementedError(
+          "only slices of the form :n (start=0, step=1) are supported"
+        )
+      stop = key.stop
+      if stop is None:
+        stop = self.shape[0]
+      if stop < 0:
+        raise ValueError(f"slice stop must be non-negative, got {stop}")
+      new_shape = (stop,) + self.shape[1:]
+      return StridedArray(
+        self.data,
+        shape=new_shape,
+        strides=self.strides,
+        offset=self.offset,
+      )
+
+    if isinstance(key, int):
+      if key < 0:
+        key += self.shape[0]
+      if key < 0 or key >= self.shape[0]:
+        raise IndexError(f"index {key} out of range for axis size {self.shape[0]}")
+      new_offset = self.offset + key * self.strides[0]
+      new_shape = self.shape[1:]
+      new_strides = self.strides[1:]
+      return StridedArray(
+        self.data,
+        shape=new_shape,
+        strides=new_strides,
+        offset=new_offset,
+      )
+
+    raise NotImplementedError(f"unsupported index type {type(key)!r}")
+
+  def _view_as_permutation_and_slice(
+    self,
+  ) -> tuple[tuple[int, ...], tuple[slice, ...]]:
+    if self.offset != 0:
+      raise NotImplementedError("to_jax with non-zero offset is not supported")
+    if self.ndim != 2:
+      raise NotImplementedError("to_jax is only implemented for 2-D views")
+
+    d0, d1 = self.data.shape
+    s0, s1 = self.shape
+    st0, st1 = self.strides
+
+    if st1 == 1 and st0 == d1:
+      perm = (0, 1)
+    elif st0 == 1 and st1 == d1:
+      perm = (1, 0)
+    else:
+      raise NotImplementedError(
+        f"unsupported 2-D stride pattern strides={self.strides} "
+        f"for data.shape={self.data.shape}"
+      )
+
+    return perm, (slice(0, s0), slice(0, s1))
+
+  def to_jax(self) -> jax.Array:
+    if (
+      self.offset == 0
+      and self.shape == tuple(self.data.shape)
+      and self.strides == default_strides(self.shape)
+    ):
+      return self.data
+
+    if self.offset == 0 and self.ndim == 2 and self.strides == (1, 1):
+      return jnp.reshape(self.data, self.shape)
+
+    perm, post_slice = self._view_as_permutation_and_slice()
+    arr = jnp.transpose(self.data, perm)
+    return arr[post_slice]
+
+
+# Register StridedArray as a JAX pytree below isn't mandatory, but simplifies, for
+# example benchmarking, that doesn't have to handle special case before calling
+# `jax.block_until_ready()` on data elements returned by an input generating function
+# in form of StridedArray objects.
+def _strided_flatten(sa):
+    children = (sa.data,)
+    aux = (sa.shape, sa.strides, sa.offset)
+    return children, aux
+
+def _strided_unflatten(aux, children):
+    shape, strides, offset = aux
+    (data,) = children
+    return StridedArray(data, shape=shape, strides=strides, offset=offset)
+
+jax.tree_util.register_pytree_node(StridedArray, _strided_flatten, _strided_unflatten)


### PR DESCRIPTION
## Motivation

JAX-Triton needs to showcase some real world kernels working and this PR adds two fp4 GEMM implementations from AITER - in Triton and in Gluon.

Tests are run with a regular `pytest` command.

Benchmarks have an extensive runner, full CLI options of which can be viewed with a standard `--help` flag: `python benchmarks.py --help`. For benchmarking it's preferrable to restrict available GPUs, for example: `ROCR_VISIBLE_DEVICES=1 python ./benchmarks.py --iters=2 --reps=100`
