### PR TITLE
[Automation] Sync upstream/main -> amd-main

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -35,6 +35,7 @@ from jax._src import core
 from jax._src import state
 from jax._src import util
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
+from jax._src.pallas.triton import gpu_info
 import jax.extend as jex
 from jax.interpreters import ad
 from jax.interpreters import batching
@@ -378,7 +379,11 @@ def make_backend(
   # create_binder() factory function.
   device = 0
   if compute_capability is None:
-    compute_capability = triton_kernel_call_lib.get_compute_capability(device)
+    try:
+      compute_capability = triton_kernel_call_lib.get_compute_capability(device)
+    except RuntimeError:
+      # TODO(slebedev): Consider *only* using ``gpu_info`` here.
+      compute_capability = gpu_info.get_gpu_info().compute_capability
   if num_ctas > 1 and compute_capability < 90:
     raise ValueError("num_ctas > 1 unsupported before Hopper.")
 

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -851,23 +851,12 @@ def triton_kernel_call_lowering(
     kernel_call = kernel_calls[0]
 
   call_proto = kernel_call.to_proto(kernel_call_name, serialized_metadata)
-
-  # TODO(phawkins): remove forward_compat after 2026-05-04
-  if jax.__version_info__ < (0, 10, 1) or ctx.is_forward_compat():
-    rule = jax.ffi.ffi_lowering(
-        "triton_kernel_call",
-        api_version=2,
-        backend_config=zlib.compress(call_proto),
-        operand_output_aliases=input_output_aliases,
-    )
-    return rule(ctx, *array_args)
-  else:
-    rule = jax.ffi.ffi_lowering(
-        "triton_kernel_call_ffi",
-        api_version=4,
-        operand_output_aliases=input_output_aliases,
-    )
-    return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
+  rule = jax.ffi.ffi_lowering(
+      "triton_kernel_call_ffi",
+      api_version=4,
+      operand_output_aliases=input_output_aliases,
+  )
+  return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
 
 
 mlir.register_lowering(

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -851,12 +851,23 @@ def triton_kernel_call_lowering(
     kernel_call = kernel_calls[0]
 
   call_proto = kernel_call.to_proto(kernel_call_name, serialized_metadata)
-  rule = jax.ffi.ffi_lowering(
-      "triton_kernel_call_ffi",
-      api_version=4,
-      operand_output_aliases=input_output_aliases,
-  )
-  return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
+
+  # TODO(phawkins): remove forward_compat after 2026-05-04
+  if jax.__version_info__ < (0, 10, 1) or ctx.is_forward_compat():
+    rule = jax.ffi.ffi_lowering(
+        "triton_kernel_call",
+        api_version=2,
+        backend_config=zlib.compress(call_proto),
+        operand_output_aliases=input_output_aliases,
+    )
+    return rule(ctx, *array_args)
+  else:
+    rule = jax.ffi.ffi_lowering(
+        "triton_kernel_call_ffi",
+        api_version=4,
+        operand_output_aliases=input_output_aliases,
+    )
+    return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
 
 
 mlir.register_lowering(

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -33,7 +33,11 @@ from jax import tree_util
 from jax._src import core
 from jax._src import util
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
-from jax._src.pallas.triton import gpu_info
+
+try:  # TODO(Arech): remove try block once gpu_info is in all supported versions
+  from jax._src.pallas.triton import gpu_info
+except ImportError:
+  gpu_info = None  # type: ignore
 import jax.extend as jex
 from jax.interpreters import ad
 from jax.interpreters import batching
@@ -351,8 +355,11 @@ def make_backend(
     try:
       compute_capability = triton_kernel_call_lib.get_compute_capability(device)
     except RuntimeError:
-      # TODO(slebedev): Consider *only* using ``gpu_info`` here.
-      compute_capability = gpu_info.get_gpu_info().compute_capability
+      if gpu_info is None:
+        # TODO(slebedev): Consider *only* using ``gpu_info`` here.
+        compute_capability = gpu_info.get_gpu_info().compute_capability
+      else:
+        raise RuntimeError("compute_capability is not available")
   if num_ctas > 1 and compute_capability < 90:
     raise ValueError("num_ctas > 1 unsupported before Hopper.")
 


### PR DESCRIPTION
Automated sync of `upstream/main`, targeting `amd-main`.

## What this PR does
- Integrates the latest `upstream/main` commits onto `amd-main`.
- **`.github/` is intentionally NOT synced** - `amd-main` keeps its own copy.

## Upstream commits included in this PR
```
09ed933 Removed a stale forward compatibility guard in the lowering
bd3ba95 Removed a stale forward compatibility guard in the lowering
ff101d3 [jax_triton] Use `gpu_info` to resolve compute capability if a device is missing
```
_Total: 3 commit(s) in range `bde814d2e7691ff55c59442d00ed8a6d2dcd920b..09ed933b8bdd9c5a50583a363c04665e8a9a8fdf`._

## How to merge  (IMPORTANT)
Use **"Create a merge commit"**. Do **NOT** squash and do **NOT** rebase-merge.

A merge commit records that `amd-main` now contains `upstream/main`'s commits as
ancestors, so the next sync treats them as already-integrated and only
brings in genuinely new work. Squashing or rebasing rewrites/collapses the
upstream commit IDs, breaking that ancestry link - every subsequent run would
then re-detect the same upstream changes as "new" and regenerate conflicts.
If that happens, re-linking commit has to be added to the base branch manually
by executing 'git merge -s ours <upstream-tip>' (safe only when the 
already-merged content matches that tip).
