### PR TITLE
restore correct handling of git diff exit codes

### DIFF
--- a/.github/workflows/amd-sync-upstream2.yml
+++ b/.github/workflows/amd-sync-upstream2.yml
@@ -277,7 +277,7 @@ jobs:
           git add -A .github
 
           # Remaining conflicts are, by construction, outside .github.
-          REMAINING_CONFLICTS="$(git diff --name-only --diff-filter=U)"
+          REMAINING_CONFLICTS="$(git diff --name-only --diff-filter=U || true)"
           if [ -n "$REMAINING_CONFLICTS" ]; then
             HAS_CONFLICTS=true
           else
@@ -347,7 +347,7 @@ jobs:
                   # temp-path file header and keeps only the @@ hunks.
                   git --no-pager diff --no-index --diff-algorithm=histogram \
                     --word-diff=plain -- "$o" "$t" 2>/dev/null \
-                    | awk 'p||/^@@/{p=1; print}' | head -200
+                    | awk 'p||/^@@/{p=1; print}' | head -200 || true
                   printf '```\n\n'
                 fi
               } >> "$CONFLICT_REPORT"
@@ -448,7 +448,7 @@ jobs:
               echo "for f in \$(git diff --name-only --diff-filter=U); do"
               echo "  echo \"=== \$f ===\""
               echo "  git --no-pager diff --no-index --word-diff=plain \\"
-              echo "    <(git show \":2:\$f\") <(git show \":3:\$f\")"
+              echo "    <(git show \":2:\$f\") <(git show \":3:\$f\") || true"
               echo "done"
               echo
               echo "# ...resolve every conflicted file, then keep ${BASE_BRANCH}'s .github sovereign:"


### PR DESCRIPTION
`git diff` return error code 1 when files are different, but this doesn't go well with `set -euo pipefail`
