### PR TITLE
[Automation] Sync upstream/main -> z_automation/upstream-sync/20260715T062249Z-ebe4394

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # ratchet:actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # ratchet:pre-commit/action@v3.0.1
   test:
     runs-on: linux-x86-g2-48-l4-4gpu
@@ -27,10 +27,10 @@ jobs:
       image:  index.docker.io/library/ubuntu@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97 # ratchet:ubuntu:22.04
     steps:
     -   uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4
-    -   name: Set up Python 3.11
+    -   name: Set up Python 3.12
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # ratchet:actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
     -   name: Setup Released JAX and Torch
         run: |
           # triton needs a compiler

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-ast
   - id: check-merge-conflict
@@ -21,11 +21,26 @@ repos:
   - id: debug-statements
     # only include python files
     files: \.py$
+    language_version: python3.12
   - id: trailing-whitespace
     # only include python and markdown files
     files: \.(py|md)$
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 8b5112a3b2ad121439a2092f8ff548c0d80f2514  # frozen: v0.6.1
+  rev: 0470f7c8a653e950f7cc5a653204ceb3fde4c02a  # frozen: v0.15.1
   hooks:
   - id: ruff
+
+- repo: https://github.com/facebook/pyrefly-pre-commit
+  rev: 14025642291adc2db2f9d9fa398e98699ef3fafc  # frozen: v1.1.1
+  hooks:
+    - id: pyrefly-check
+      name: Pyrefly (type checking)
+      pass_filenames: false
+      additional_dependencies:
+        - numpy~=2.4.0
+        - triton~=3.6.0
+        - --pre
+        - --extra-index-url
+        - https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/
+        - jax

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -38,7 +38,6 @@ from jax._src import util
 from jax._src.frozen_dict import FrozenDict
 from jax._src.interpreters import partial_eval as pe
 from jax._src.lib import gpu_triton as triton_kernel_call_lib
-from jax._src.pallas.triton import gpu_info
 import jax.extend as jex
 from jax.interpreters import ad
 from jax.interpreters import batching
@@ -55,15 +54,19 @@ import triton.language as tl
 import triton.runtime.autotuner as autotuner
 
 try:
+  from jax._src.pallas.triton import gpu_info  # pyrefly: ignore[missing-module-attribute]
+except ImportError:
+  gpu_info = None  # Only available in JAX 0.11.0+.
+
+try:
   import triton.backends.nvidia.compiler as cb
 except ImportError:
-  cb = None  # NVIDIA backend is not available.
+  cb: Any = None  # NVIDIA backend is not available.
 
 try:
   import triton.backends.amd.compiler as hb
 except ImportError:
-  hb = None  # AMD backend is not available.
-
+  hb: Any = None  # AMD backend is not available.
 
 # TODO(slebedev): Investigate if this is necessary.
 if "TRITON_CACHE_DIR" in os.environ:
@@ -122,7 +125,7 @@ def normalize_grid(grid: ValueOrFn[Grid], metaparams) -> tuple[int, int, int]:
     grid = (grid,)
   elif len(grid) > 3:
     raise ValueError("`grid` should have three or fewer dimensions.")
-  return tuple(grid) + (1,) * (3 - len(grid))
+  return tuple(grid) + (1,) * (3 - len(grid))  # pyrefly: ignore[bad-return]
 
 
 def get_type_id(obj: Any) -> str:
@@ -388,8 +391,8 @@ def compile_ttir_to_hsaco_inplace(
 
 
 def make_backend(
-  make_gpu_target_func, compute_capability: int | None, num_ctas: int
-) -> tuple[tc.BaseBackend, tc.GPUTarget, int]:
+    make_gpu_target_func, compute_capability: int | None, num_ctas: int
+) -> tuple[cb.CUDABackend | hb.HIPBackend, tc.GPUTarget, int]:
   """Resolves compute_capability and creates Triton's Backend and GPUTarget objects."""
 
   # TODO(sharadmv): handle multiple devices, right now we assume device 0
@@ -403,6 +406,8 @@ def make_backend(
     try:
       compute_capability = triton_kernel_call_lib.get_compute_capability(device)
     except RuntimeError:
+      if gpu_info is None:
+        raise
       # TODO(slebedev): Consider *only* using ``gpu_info`` here.
       compute_capability = gpu_info.get_gpu_info().compute_capability
   if num_ctas > 1 and compute_capability < 90:
@@ -516,7 +521,7 @@ class JTJITFunction:
     alignments = [16] * len(arg_dtypes)
     for i, _, _ in scalar_args:
       alignments[i] = 0
-    specialize_impl = _triton.native_specialize_impl
+    specialize_impl = _triton.native_specialize_impl  # pyrefly: ignore[missing-attribute]
     is_const = False
     do_specialize = True
     specialization = [
@@ -550,8 +555,9 @@ class JTJITFunction:
         tuple(sorted(backend_options.items())),
     )
     if not hasattr(self.fn, "_jT_kernel_cache"):
-      self.fn._jT_kernel_cache = {}  # TODO(cjfj): Convert to LRU cache?
-    kernel = self.fn._jT_kernel_cache.get(cache_key)
+      # TODO(cjfj): Convert to LRU cache?
+      self.fn._jT_kernel_cache = {}  # pyrefly: ignore[missing-attribute]
+    kernel = self.fn._jT_kernel_cache.get(cache_key)  # pyrefly: ignore[missing-attribute]
 
     if kernel is None:
       # First, check that the kernel signature and the reconstructed signature have the
@@ -567,7 +573,7 @@ class JTJITFunction:
           "implicit output arguments are no longer required for aliased arguments."
         )
 
-      options = backend.parse_options(backend_options)
+      options = backend.parse_options(backend_options)  # pyrefly: ignore[bad-argument-type]
 
       kernel_hash = abs(hash(cache_key))
       if _JAX_TRITON_DUMP_DIR:
@@ -576,8 +582,8 @@ class JTJITFunction:
           pprint.pprint(cache_key, stream=f)
           pprint.pprint(options, stream=f)
 
-      context = _triton.ir.context()
-      _triton.ir.load_dialects(context)
+      context = _triton.ir.context()  # pyrefly: ignore[missing-attribute]
+      _triton.ir.load_dialects(context)  # pyrefly: ignore[missing-attribute]
       backend.load_dialects(context)
       codegen_fns = backend.get_codegen_implementation(options)
 
@@ -629,15 +635,15 @@ class JTJITFunction:
         compute_capability,
       )
 
-      self.fn._jT_kernel_cache[cache_key] = kernel
+      self.fn._jT_kernel_cache[cache_key] = kernel  # pyrefly: ignore[missing-attribute]
 
     return kernel, attrs
 
 
 def make_autotuner_configs(
-  fn: autotuner.Autotuner,
-  kwargs: dict[str, Any],
-  named_args: dict[str, Any],
+    fn: autotuner.Autotuner,
+    kwargs: Mapping[str, Any],
+    named_args: Mapping[str, Any],
 ) -> list[triton.Config]:
   """Make and prune redundant autotuner configs based on user-provided kwargs.
 
@@ -671,16 +677,16 @@ def make_autotuner_configs(
     return pruned_configs
 
   fn.early_config_prune = prune_configs
-  fn.nargs = named_args
-  configs = fn.prune_configs(kwargs)
+  fn.nargs = named_args  # pyrefly: ignore[bad-assignment]
+  configs = fn.prune_configs(kwargs)  # pyrefly: ignore[bad-argument-type]
   return configs
 
 
 def apply_heuristics(
-  fn: autotuner.Heuristics,
-  configs: list[triton.Config],
-  orig_kwargs: dict[str, Any],
-  named_args: dict[str, Any],
+    fn: autotuner.Heuristics,
+    configs: list[triton.Config],
+    orig_kwargs: Mapping[str, Any],
+    named_args: Mapping[str, Any],
 ) -> list[triton.Config]:
   """Applies heuristics to the configs and returns the updated configs."""
   updated_configs = []

--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -491,25 +491,19 @@ class JTJITFunction:
     return len(self.fn._jT_kernel_cache) if hasattr(self.fn, "_jT_kernel_cache") else 0
 
   def get_or_create_triton_kernel(
-    self,
-    make_gpu_target_func,
-    platform,
-    arg_dtypes,
-    scalar_args,
-    *,
-    num_warps,
-    num_stages,
-    num_ctas,
-    compute_capability,
-    enable_fp_fusion,
-    metaparams,
-    dump: bool,
+      self,
+      make_gpu_target_func,
+      platform,
+      arg_dtypes,
+      scalar_args,
+      *,
+      compute_capability,
+      backend_options: Mapping[str, Any],
+      metaparams,
   ) -> tuple[triton_kernel_call_lib.TritonKernel, Any]:
     fn = self.fn
-    if num_warps is None:
-      num_warps = 4
-    if num_stages is None:
-      num_stages = 3
+    num_warps = backend_options["num_warps"]
+    num_ctas = backend_options["num_ctas"]
 
     backend, gpu_target, compute_capability = make_backend(
       make_gpu_target_func, compute_capability, num_ctas
@@ -548,15 +542,12 @@ class JTJITFunction:
 
     # Cache key should contain any parameter that can affect the compiler output.
     cache_key = (
-      fn,
-      tuple(signature.items()),
-      tuple(specialization),
-      tuple(constants.items()),
-      num_warps,
-      num_stages,
-      num_ctas,
-      compute_capability,
-      enable_fp_fusion,
+        fn,
+        tuple(signature.items()),
+        tuple(specialization),
+        tuple(constants.items()),
+        compute_capability,
+        tuple(sorted(backend_options.items())),
     )
     if not hasattr(self.fn, "_jT_kernel_cache"):
       self.fn._jT_kernel_cache = {}  # TODO(cjfj): Convert to LRU cache?
@@ -576,16 +567,7 @@ class JTJITFunction:
           "implicit output arguments are no longer required for aliased arguments."
         )
 
-      opts = {
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "num_ctas": num_ctas,
-        "optimize_epilogue": False,
-        "debug": dump,
-        "enable_fp_fusion": enable_fp_fusion,
-      }
-
-      options = backend.parse_options(opts)
+      options = backend.parse_options(backend_options)
 
       kernel_hash = abs(hash(cache_key))
       if _JAX_TRITON_DUMP_DIR:
@@ -721,14 +703,10 @@ def triton_kernel_call_lowering(
     name,
     out_shapes,
     grid,
-    num_warps,
-    num_stages,
-    num_ctas,
     compute_capability,
-    enable_fp_fusion,
+    backend_options: FrozenDict[str, Any],
     input_output_aliases: FrozenDict[int, int],
     zeroed_outputs,
-    debug,
     serialized_metadata,
     metaparams: FrozenDict[str, Any],
     has_side_effect: bool = False,
@@ -755,10 +733,10 @@ def triton_kernel_call_lowering(
     fn = fn.fn
   else:
     config = triton.Config(
-      {},
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
+        {},
+        num_warps=backend_options["num_warps"],
+        num_stages=backend_options["num_stages"],
+        num_ctas=backend_options["num_ctas"],
     )
     configs = [config]
 
@@ -806,18 +784,20 @@ def triton_kernel_call_lowering(
         for i in sorted(config_zeroed_outputs)
     }
 
+    config_backend_options = {
+        **backend_options,
+        "num_warps": config.num_warps,
+        "num_stages": config.num_stages,
+        "num_ctas": config.num_ctas,
+    }
     kernel, specialization_attr = jtfu.get_or_create_triton_kernel(
         make_gpu_target_func,
         ctx.module_context.platforms[0],
         arg_dtypes,
         scalar_args,
-        num_warps=config.num_warps,
-        num_stages=config.num_stages,
-        num_ctas=config.num_ctas,
         compute_capability=compute_capability,
-        enable_fp_fusion=enable_fp_fusion,
+        backend_options=config_backend_options,
         metaparams=config_metaparams,
-        dump=debug,
     )
 
     kernel_params = []
@@ -931,9 +911,10 @@ def triton_call(
     name: str = "",
     num_warps: int | None = None,
     num_stages: int | None = None,
-    num_ctas: int = 1,  # TODO(giorgioa): Add support for dimensions tuple.
+    # TODO(giorgioa): Add support for dimensions tuple.
+    num_ctas: int | None = None,
     compute_capability: int | None = None,
-    enable_fp_fusion: bool = True,
+    backend_options: Mapping[str, Any] | None = None,
     input_output_aliases: dict[int, int] | None = None,
     zeroed_outputs: ValueOrFn[Sequence[int]] = (),
     debug: bool = False,
@@ -1008,8 +989,6 @@ def triton_call(
       tuple of up to 3 integers.
     name: A name for the kernel call.
     compute_capability: The GPU compute capability to compile for.
-    enable_fp_fusion: Whether to enable floating-point operation fusion in the
-      Triton compiler.
     input_output_aliases: A dictionary mapping input argument indices to output
       indices. Providing a mapping will alias the corresponding buffers. The
       input indices are positions in the original ``*args``.
@@ -1023,6 +1002,10 @@ def triton_call(
     num_ctas: The size of thread blocks per cluster to be used on GPUs with
       compute capabilities >= 9.0. It must be less or equal to 8.
     debug: Prints out intermediate IRs if True for debugging purposes.
+    backend_options: A mapping of backend-specific compiler options. The
+      available options depend on the Triton backend. The ``num_warps``,
+      ``num_stages``, ``num_ctas`` and ``debug`` are merged into this mapping.
+      It is an error to specify the same option in both.
     serialized_metadata: Arbitrary metadata that will be added into the
       serialized kernel call.
     has_side_effect: Whether the Triton kernel has side effects.
@@ -1032,6 +1015,29 @@ def triton_call(
   Returns:
     Outputs from the Triton kernel.
   """
+  if backend_options is None:
+    backend_options = {}
+  explicit_options = {
+      "num_warps": num_warps,
+      "num_stages": num_stages,
+      "num_ctas": num_ctas,
+      "debug": debug,
+  }
+  del num_ctas, num_stages, num_warps, debug
+  for k, v in list(explicit_options.items()):
+    if v is None:
+      del explicit_options[k]
+
+  if conflicts := explicit_options.keys() & backend_options.keys():
+    raise ValueError(
+        f"Cannot specify {conflicts} both as explicit arguments and in"
+        " ``backend_options``"
+    )
+  backend_options = {**backend_options, **explicit_options}
+  backend_options.setdefault("num_warps", 4)
+  backend_options.setdefault("num_stages", 3)
+  backend_options.setdefault("num_ctas", 1)
+
   out_shape = tree_util.tree_map(
       lambda a: jax.ShapeDtypeStruct(a.shape, a.dtype), out_shape
   )
@@ -1059,14 +1065,10 @@ def triton_call(
       name=name,
       out_shapes=tuple(flat_out_shapes),
       grid=grid,
-      num_warps=num_warps,
-      num_stages=num_stages,
-      num_ctas=num_ctas,
       compute_capability=compute_capability,
-      enable_fp_fusion=enable_fp_fusion,
+      backend_options=FrozenDict(backend_options),
       input_output_aliases=FrozenDict(input_output_aliases),
       zeroed_outputs=zeroed_outputs,
-      debug=debug,
       serialized_metadata=serialized_metadata,
       has_side_effect=has_side_effect,
       metaparams=FrozenDict(metaparams),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "jax-triton"
 dynamic = ["version"]
 description = "JAX + OpenAI Triton integration"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
   "absl-py>=1.4.0",
   "jax>=0.8.2",
@@ -26,6 +26,16 @@ packages = ["jax_triton"]
 [tool.setuptools.dynamic]
 version = {attr = "jax_triton.version.__version__"}
 
+[tool.pyrefly]
+python-version = "3.13"
+project-includes = [
+    "jax_triton/**/*.py*",
+]
+untyped-def-behavior = "check-and-infer-return-any"
+
+[tool.pyrefly.errors]
+redefinition = "ignore"
+
 [tool.ruff]
 preview = true
 exclude = [
@@ -36,7 +46,7 @@ exclude = [
 ]
 line-length = 88
 indent-width = 2
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
 ignore = [

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -743,6 +743,17 @@ class TritonKernelCallTest(parameterized.TestCase):
     ]
     self.assertLen(dce_eqns, 1)
 
+  def test_backend_options(self):
+    x, y = create_random_inputs([8])
+    out = add(x, y, backend_options={"num_warps": 2}, BLOCK_SIZE=8)
+    expected = x + y
+    np.testing.assert_allclose(out, expected)
+
+  def test_backend_options_conflict(self):
+    x, y = create_random_inputs([8])
+    with self.assertRaisesRegex(ValueError, "backend_options"):
+      add(x, y, num_warps=4, backend_options={"num_warps": 2}, BLOCK_SIZE=8)
+
 
 if __name__ == "__main__":
   os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.5"


### PR DESCRIPTION
Automated sync of `upstream/main`, targeting `z_automation/upstream-sync/20260715T062249Z-ebe4394`.

## Stacked PR
**This PR is stacked on #20 (its base is `z_automation/upstream-sync/20260715T062249Z-ebe4394`).
That previous PR must be merged first, as this one is based on it.**
Merge the stack bottom-up (oldest first).

## What this PR does
- Integrates the latest `upstream/main` commits onto `z_automation/upstream-sync/20260715T062249Z-ebe4394`.
- **`.github/` is intentionally NOT synced** - `amd-main` keeps its own copy.

## Upstream commits included in this PR
```
eef6bef Merge pull request #412 from superbobry:pyrefly
0dbda6c Added Pyrefly to the pre-commit config
413bdea `triton_call` now accepts arbitrary backend options
```
_Total: 3 commit(s) in range `ebe439427a13a6d3f2ee76d37be7cdf0b9604a16..eef6beffd902fdda98b7184853fc891b21fb41b0`._

## How to merge  (IMPORTANT)
Use **"Create a merge commit"**. Do **NOT** squash and do **NOT** rebase-merge.

A merge commit records that `z_automation/upstream-sync/20260715T062249Z-ebe4394` now contains `upstream/main`'s commits as
ancestors, so the next sync treats them as already-integrated and only
brings in genuinely new work. Squashing or rebasing rewrites/collapses the
upstream commit IDs, breaking that ancestry link - every subsequent run would
then re-detect the same upstream changes as "new" and regenerate conflicts.
If that happens, re-linking commit has to be added to the base branch manually
by executing 'git merge -s ours <upstream-tip>' (safe only when the 
already-merged content matches that tip).
