### PR TITLE
[Automation] Sync upstream/main -> z_automation/upstream-sync/20260723T062504Z-892a73d

### DIFF
--- a/jax_triton/triton_lib.py
+++ b/jax_triton/triton_lib.py
@@ -22,12 +22,13 @@ import dataclasses
 import functools
 from functools import cached_property
 import inspect
+import json
 import os
 import pprint
 import shutil
 import tempfile
 import types
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, Self, TypeVar, TypedDict
 import zlib
 
 import jax
@@ -87,6 +88,12 @@ except ImportError:
 if "TRITON_CACHE_DIR" in os.environ:
   del os.environ["TRITON_CACHE_DIR"]
 _JAX_TRITON_DUMP_DIR = os.environ.get("JAX_TRITON_DUMP_DIR")
+
+
+class CostEstimate(TypedDict, total=False):
+  flops: int
+  bytes_accessed: int
+
 
 _HSACO_TMPDIR = tempfile.TemporaryDirectory(delete=True)
 
@@ -752,6 +759,7 @@ def triton_kernel_call_lowering(
     serialized_metadata,
     metaparams: FrozenDict[str, Any],
     has_side_effect: bool = False,
+    cost_estimate: CostEstimate | None = None,
 ):
   if triton_kernel_call_lib is None:
     raise _missing_gpu_support_error()
@@ -909,7 +917,10 @@ def triton_kernel_call_lowering(
       operand_output_aliases=input_output_aliases,
       has_side_effect=has_side_effect,
   )
-  return rule(ctx, *array_args, opaque=zlib.compress(call_proto))
+  kwargs: dict[str, Any] = {"opaque": zlib.compress(call_proto)}
+  if cost_estimate is not None:
+    kwargs["cost_estimate_json"] = json.dumps(dict(cost_estimate))
+  return rule(ctx, *array_args, **kwargs)
 
 
 mlir.register_lowering(
@@ -986,6 +997,7 @@ def triton_call(
     zeroed_outputs: ValueOrFn[Sequence[int]] = (),
     debug: bool = False,
     serialized_metadata: bytes = b"",
+    cost_estimate: CostEstimate | None = None,
     has_side_effect: bool = False,
     **metaparams: Any,
 ) -> Any:
@@ -1077,11 +1089,14 @@ def triton_call(
       It is an error to specify the same option in both.
     serialized_metadata: Arbitrary metadata that will be added into the
       serialized kernel call.
+    cost_estimate: An estimate of the number of floating point operations
+      ("flops") and memory bytes accessed ("bytes_accessed") by this kernel
+      invocation. This is used by profiling tools to compute the performance
+      metrics of this custom call (e.g. FLOPs/s and bandwidth).
     has_side_effect: Whether the Triton kernel has side effects.
     **metaparams: ``constexpr`` arguments for the Triton kernel. Missing
-      constexpr arguments are filled from the kernel's declared defaults.
-      Also provided to ``grid`` and ``zeroed_outputs`` when either is a
-      function.
+      constexpr arguments are filled from the kernel's declared defaults. Also
+      provided to ``grid`` and ``zeroed_outputs`` when either is a function.
 
   Returns:
     Outputs from the Triton kernel.
@@ -1137,6 +1152,7 @@ def triton_call(
       input_output_aliases=FrozenDict(input_output_aliases),
       zeroed_outputs=zeroed_outputs,
       serialized_metadata=serialized_metadata,
+      cost_estimate=FrozenDict(cost_estimate) if cost_estimate else None,
       has_side_effect=has_side_effect,
       metaparams=FrozenDict(metaparams),
   )

--- a/tests/triton_call_test.py
+++ b/tests/triton_call_test.py
@@ -197,7 +197,6 @@ def create_random_inputs(shape1, shape2=None, *, dtype="float32"):
   return x, y
 
 
-
 class TritonKernelCallTest(parameterized.TestCase):
 
   @parameterized.product(
@@ -917,6 +916,30 @@ class TritonKernelCallTest(parameterized.TestCase):
         BLOCK_SIZE=8,
     )
     np.testing.assert_allclose(out, x + y)
+
+  def test_cost_estimate(self):
+    x, y = create_random_inputs([8])
+    cost = {"flops": 123, "bytes_accessed": 456}
+
+    def add_with_cost(x, y):
+      default_grid = lambda meta: triton.cdiv(x.size, meta["BLOCK_SIZE"])
+      return jt.triton_call(
+          x,
+          y,
+          x.size,
+          kernel=add_kernel,
+          out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+          grid=default_grid,
+          BLOCK_SIZE=8,
+          cost_estimate=cost,
+      )
+
+    hlo = jax.jit(add_with_cost).lower(x, y).compiler_ir("hlo").as_hlo_text()
+    self.assertIn("cost_estimate_json", hlo)
+    self.assertRegex(hlo, r"cost_estimate_json\s*=\s*.*flops\\22\s*:\s*123")
+    self.assertRegex(
+        hlo, r"cost_estimate_json\s*=\s*.*bytes_accessed\\22\s*:\s*456"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automated sync of `upstream/main`, targeting `z_automation/upstream-sync/20260723T062504Z-892a73d`.

## Stacked PR
**This PR is stacked on #25 (its base is `z_automation/upstream-sync/20260723T062504Z-892a73d`).
That previous PR must be merged first, as this one is based on it.**
Merge the stack bottom-up (oldest first).

## What this PR does
- Integrates the latest `upstream/main` commits onto `z_automation/upstream-sync/20260723T062504Z-892a73d`.
- **`.github/` is intentionally NOT synced** - `amd-main` keeps its own copy.

## Upstream commits included in this PR
```
e7751e8 Support extracting custom call cost estimates for JAX Triton kernels.
```
_Total: 1 commit(s) in range `892a73db9aa62cfeb6753c9ebb3e5c786c1262ab..e7751e8876fd21baf7efee395b4b271b8bf01e0d`._

## How to merge  (IMPORTANT)
Use **"Create a merge commit"**. Do **NOT** squash and do **NOT** rebase-merge.

A merge commit records that `z_automation/upstream-sync/20260723T062504Z-892a73d` now contains `upstream/main`'s commits as
ancestors, so the next sync treats them as already-integrated and only
brings in genuinely new work. Squashing or rebasing rewrites/collapses the
upstream commit IDs, breaking that ancestry link - every subsequent run would
then re-detect the same upstream changes as "new" and regenerate conflicts.
If that happens, re-linking commit has to be added to the base branch manually
by executing 'git merge -s ours <upstream-tip>' (safe only when the 
already-merged content matches that tip).
